### PR TITLE
component refactor & auth only routes

### DIFF
--- a/less/less.main.less
+++ b/less/less.main.less
@@ -1,4 +1,4 @@
-@font-stack:    "century gothic", sans-serif;
+@font-stack: "century gothic", sans-serif;
 @primary-color: #0c171b;
 
 body {
@@ -6,20 +6,19 @@ body {
   color: @primary-color;
   font-size: 1.2rem;
   background-color: #e6e7e8;
-}
-
-body,html {
-  height: 100%;
+  display: flex;
 }
 
 #sidebar {
-   padding-left:0;
-   text-align: center;
-   background-color: #0c171b;
-   color: #cffffd;
-   top: 0;
-   bottom: 0;
-   height: 100%;
+  padding-left: 0;
+  text-align: center;
+  background-color: #0c171b;
+  color: #cffffd;
+  top: 0;
+  bottom: 0;
+  height: 100%;
+  width: 220px;
+  order: 0;
 }
 
 .owlet {
@@ -27,7 +26,7 @@ body,html {
 }
 
 .menu {
-  padding-top:10px;
+  padding-top: 10px;
   margin-bottom: -9999px;
   padding-bottom: 9999px;
   overflow: hidden;
@@ -37,24 +36,29 @@ body,html {
     margin: 30px;
   }
   h1 {
-    margin-top:10px;
+    margin-top: 10px;
     margin-bottom: 25px;
     font-size: 3em;
     font-weight: 100;
   }
 }
 
-.custom-header {
-  height:145px;
+// TODO: touch this class
+#header {
+  height: 145px;
   overflow: hidden;
+  flex-direction: row;
+  order: 1;
   img {
     height: auto;
     width: 100%;
   }
-  button {
-    position:absolute;
-    top: 113px;
-  }
+}
+
+#change-header-btn {
+  top: 113px;
+  position: absolute;
+
 }
 
 /* buttons and inputs */
@@ -82,12 +86,14 @@ button {
 
 /* main content */
 
+#main {
+  flex-direction: row;
+}
+
+// TODO: touch this class
+// affects .header & .main areas
 .content {
-  margin: 35px;
-  h1 {
-    margin-bottom: 20px;
-    font-size: 2rem;
-  }
+
 }
 
 /* no gutters! */

--- a/resources/index.html
+++ b/resources/index.html
@@ -7,7 +7,11 @@
     <link href="css/less.css" rel="stylesheet" type="text/css" media="screen">
   </head>
   <body>
-    <div id="mount"></div>
+    <div id="sidebar"></div>
+    <div class="content">
+      <div id="header"></div>
+      <div id="main"></div>
+    </div>
     <script type="text/javascript" src="js/app.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="http://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js"></script>

--- a/src/cljs/owlet/app.cljs
+++ b/src/cljs/owlet/app.cljs
@@ -18,7 +18,7 @@
        [:div.search.pull-right
         [:input {:type "search"
                  :name "sitesearch"}]
-        [:input {:type "submit"
+        [:input {:type  "submit"
                  :value "\uD83D\uDD0D"}]]
        [:div.container-fluid
         [:div.row
@@ -50,7 +50,12 @@
             (events/listen
               HistoryEventType/NAVIGATE
               (fn [event]
-                  (secretary/dispatch! (.-token event))))
+                  (let [url (.-token event)]
+                       (if-not (= url "/")
+                               (if (session/get :is-logged-in?)
+                                 (secretary/dispatch! url)
+                                 (secretary/dispatch! "/"))
+                               (secretary/dispatch! url)))))
             (.setEnabled true)))
 
 ;; -------------------------

--- a/src/cljs/owlet/app.cljs
+++ b/src/cljs/owlet/app.cljs
@@ -2,7 +2,6 @@
   (:require
     [owlet.views.settings :refer [settings-page]]
     [owlet.components.header :refer [header-component]]
-    [owlet.components.login :refer [login-component]]
     [owlet.components.sidebar :refer [sidebar-component]]
     [reagent.core :as reagent :refer [atom]]
     [reagent.session :as session]
@@ -14,26 +13,18 @@
 (enable-console-print!)
 
 (defn main-page []
-     [:div.no-gutter
-      [:div.container-fluid
-       [:div.row.row-offcanvas.row-offcanvas-left
-        [sidebar-component]
-        [:div.col-md-9.col-lg-10
-         [header-component]
-         [:span.hidden-md-up
-           [:button.btn-primary.btn-md {:type "button"
-                                        :data-toggle "offcanvas"
-                                        :onClick
-                                          (fn []
-                                            (-> (js/$ ".row-offcanvas")
-                                              (.toggleClass "active")))} "Menu"]]
-         [:div.login
-          [login-component]]
-         [:div.search.pull-right
-          [:input {:type "search"
-                   :name "sitesearch"}]
-          [:input {:type "submit"
-                   :value "\uD83D\uDD0D"}]]]]]])
+      [:div.jumbotron
+       ;; TODO: refactor search into own component
+       [:div.search.pull-right
+        [:input {:type "search"
+                 :name "sitesearch"}]
+        [:input {:type "submit"
+                 :value "\uD83D\uDD0D"}]]
+       [:div.container-fluid
+        [:div.row
+         [:div.col-lg-12
+          [:p.text-center
+           "main content area"]]]]])
 
 (def pages
   {:main     #'main-page
@@ -65,8 +56,12 @@
 ;; -------------------------
 ;; Initialize app
 (defn mount-components []
+      (reagent/render [#'sidebar-component]
+                      (.getElementById js/document "sidebar"))
+      (reagent/render [#'header-component]
+                      (.getElementById js/document "header"))
       (reagent/render [#'page]
-                      (.getElementById js/document "mount")))
+                      (.getElementById js/document "main")))
 
 (defn init! []
       (hook-browser-navigation!)

--- a/src/cljs/owlet/components/header.cljs
+++ b/src/cljs/owlet/components/header.cljs
@@ -9,8 +9,10 @@
       (let [img-src (atom (or (.getItem js/localStorage "custom-image-url")
                               "http://eskipaper.com/images/space-1.jpg"))]
            (fn []
-               [:div.custom-header
-                [:button.btn-primary-outline.btn-sm
+               [:div#header
+                [:div.login
+                 [login-component]]
+                [:button#change-header-btn.btn-primary-outline.btn-sm
                  {:onClick
                   (fn []
                       (let [url (js/prompt "i need a url")]

--- a/src/cljs/owlet/components/login.cljs
+++ b/src/cljs/owlet/components/login.cljs
@@ -29,6 +29,7 @@
                                    (do
                                      (get-user-cms-profile (.-user_id profile))
                                      (swap! is-logged-in? not)
+                                     (session/put! :is-logged-in? true)
                                      (session/put! :user-id (.-user_id profile)))))))]
            (fn []
                [:button.btn.btn-success.btn-sm
@@ -40,12 +41,14 @@
                                                  (print err)
                                                  (do
                                                    (session/put! :user-id (.-user_id profile))
+                                                   (session/put! :is-logged-in? true)
                                                    (.log js/console profile)
                                                    (swap! is-logged-in? not)
                                                    ;; save the JWT token
                                                    (.setItem js/localStorage "userToken" token)))))
                                     (do
                                       (swap! is-logged-in? not)
+                                      (session/put! :is-logged-in? false)
                                       (session/remove! :user-id)
                                       (.removeItem js/localStorage "userToken")))}
                  (if @is-logged-in? "Log out"

--- a/src/cljs/owlet/components/sidebar.cljs
+++ b/src/cljs/owlet/components/sidebar.cljs
@@ -3,18 +3,26 @@
     [reagent.core :refer [atom]]))
 
 (defn sidebar-component []
-   [:div#sidebar.col-md-3.col-lg-2.sidebar-offcanvas
-     [:a {:href "/#/"}
-      [:img.owlet {:src "img/owlet-logo.png"}]]
-     [:div.menu
-      [:h1 "owlet"]
-      [:ul.nav.nav-pills.nav-stacked
-       [:li.nav-item
-        [:a.nav-link {:href "/#/"}
-         [:img {:src "img/icon1.png"}]]]
-       [:li.nav-item
-        [:a.nav-link {:href "/#/"}
-         [:img {:src "img/icon2.png"}]]]
-       [:li.nav-item
-        [:a.nav-link {:href "/#/settings"}
-         [:img {:src "img/icon3.png"}]]]]]])
+      [:div#sidebar
+       [:a {:href "/#/"}
+        [:img.owlet {:src "img/owlet-logo.png"}]]
+       ;; TODO: fix responsive menu
+       [:div.menu
+        [:span.hidden-md-up
+         [:button.btn-primary.btn-md {:type        "button"
+                                      :data-toggle "offcanvas"
+                                      :onClick
+                                                   (fn []
+                                                       (-> (js/$ ".row-offcanvas")
+                                                           (.toggleClass "active")))} "Menu"]]
+        [:h1 "owlet"]
+        [:ul.nav.nav-pills.nav-stacked
+         [:li.nav-item
+          [:a.nav-link {:href "/#/"}
+           [:img {:src "img/icon1.png"}]]]
+         [:li.nav-item
+          [:a.nav-link {:href "/#/"}
+           [:img {:src "img/icon2.png"}]]]
+         [:li.nav-item
+          [:a.nav-link {:href "/#/settings"}
+           [:img {:src "img/icon3.png"}]]]]]])

--- a/src/cljs/owlet/views/settings.cljs
+++ b/src/cljs/owlet/views/settings.cljs
@@ -1,8 +1,5 @@
 (ns owlet.views.settings
   (:require
-    [owlet.components.header :refer [header-component]]
-    [owlet.components.login :refer [login-component]]
-    [owlet.components.sidebar :refer [sidebar-component]]
     [reagent.core :refer [atom]]
     [reagent.validation :as validation]
     [reagent.session :as session]
@@ -11,41 +8,24 @@
 (defonce server-url "http://localhost:3000")
 
 (defn settings-page []
-  (let [district-id (atom nil)]
-       (fn []
-         [:div.no-gutter
-          [:div.container-fluid
-           [:div.row.row-offcanvas.row-offcanvas-left
-            [sidebar-component]
-            [:div.col-md-9.col-lg-10
-             [header-component]
-             [:span.hidden-md-up
-               [:button.btn-primary.btn-md {:type "button"
-                                            :data-toggle "offcanvas"
-                                            :onClick
-                                              (fn []
-                                                (-> (js/$ ".row-offcanvas")
-                                                  (.toggleClass "active")))} "Menu"]]
-             [:div.login
-              [login-component]]
-             [:div.search.pull-right
-              [:input {:type "search"
-                       :name "sitesearch"}]
-              [:input {:type "submit"
-                       :value "\uD83D\uDD0D"}]]
-          [:div.content
-           [:h1 "My Settings"]
-           [:div.search
-            [:label "District ID:"
-             [:input.test {:type      "text"
-                           :value     @district-id
-                           :on-change #(reset! district-id (-> % .-target .-value))}]
-             [:input {:type     "submit"
-                      :value    "Enter"
-                      :on-click #(when (and (validation/has-value? (session/get :user-id))
-                                            (validation/has-value? @district-id))
-                                       (PUT (str server-url "/api/users-district-id")
-                                            {:params  {:district-id @district-id
-                                                       :user-id     (session/get :user-id)}
-                                             :handler (fn [res]
-                                                          (js/alert res))}))}]]]]]]]])))
+      (let [district-id (atom nil)]
+           (fn []
+               [:div.container
+                [:div.row
+                 [:div.col-lg-12
+                  [:div.jumbotron
+                   [:h1 "My Settings"]
+                   [:div.search
+                    [:label "District ID:"
+                     [:input.test {:type      "text"
+                                   :value     @district-id
+                                   :on-change #(reset! district-id (-> % .-target .-value))}]
+                     [:input {:type     "submit"
+                              :value    "Enter"
+                              :on-click #(when (and (validation/has-value? (session/get :user-id))
+                                                    (validation/has-value? @district-id))
+                                               (PUT (str server-url "/api/users-district-id")
+                                                    {:params  {:district-id @district-id
+                                                               :user-id     (session/get :user-id)}
+                                                     :handler (fn [res]
+                                                                  (js/alert res))}))}]]]]]]])))


### PR DESCRIPTION
connects to [#43](https://github.com/codefordenver/owl-curriculum/issues/43) and [#53](https://github.com/codefordenver/owl-curriculum/issues/53)
- first pass at react component refactor sidebar, header, main-content
- adds a bit of flexbox css for layout
- first pass at auth only routes

@eemshi this change-set breaks a lot of css but its better going forward, lets review it together next time 
@stoneyb found a simpler way to secure the routes.

@codefordenver/owlet 
