### PR TITLE
resolves dependency conflict reagent <-> devcards

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -15,9 +15,10 @@
                  [reagent-forms "0.5.22"]
                  [secretary "1.2.3"]
                  [kioo "0.4.2"]
+                 [cljsjs/jquery "2.2.2-0"]
                  [re-frame "0.7.0"]
                  [cljs-log "0.2.2"]
-                 [devcards "0.2.1-7"]])
+                 [devcards "0.2.0-8"]])
 
 (require
  '[adzerk.boot-cljs      :refer [cljs]]

--- a/resources/cards.html
+++ b/resources/cards.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>hi, world!</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha/css/bootstrap.css" media="screen" title="no title" charset="utf-8">
     <link href="css/less.css" rel="stylesheet" type="text/css" media="screen">
 </head>
 <body>

--- a/src/cljs/owlet/components/sidebar.cljs
+++ b/src/cljs/owlet/components/sidebar.cljs
@@ -1,5 +1,6 @@
 (ns owlet.components.sidebar
   (:require
+    [cljsjs.jquery]
     [reagent.core :refer [atom]]))
 
 (defn sidebar-component []

--- a/src/cljs/owlet_devcards/app.cljs
+++ b/src/cljs/owlet_devcards/app.cljs
@@ -1,15 +1,20 @@
 (ns owlet-devcards.app
   (:require [devcards.core]
             [reagent.core :as reagent]
-            )
+            [owlet.views.library :refer [library-view]]
+            [owlet.components.sidebar :refer [sidebar-component]])
   (:require-macros [devcards.core :as dc
                     :refer [defcard defcard-rg]]))
 
 (enable-console-print!)
 
-(defcard-rg rg-example-2
-            "some docs"
-            [:div "this works"])
+(defcard-rg library-view
+            "**library view**"
+            [library-view])
+
+(defcard-rg sidebar-component
+            "**our sidebar component**"
+            [sidebar-component])
 
 (defn init []
       (dc/start-devcard-ui!))


### PR DESCRIPTION
connects to [64](https://waffle.io/codefordenver/owl-curriculum/cards/5755e092c94374530282895d)

more on [devcards here](http://rigsomelight.com/devcards/#!/devdemos.core)

![screen shot 2016-06-08 at 2 11 20 pm](https://cloud.githubusercontent.com/assets/144226/15909318/f9065c34-2d82-11e6-8ac9-6493c41e4c95.png)

@eemshi we can now use devcards ^__^
