### PR TITLE
Figwheel in Cursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,80 @@
 # owlet-ui
 
-A [re-frame](https://github.com/Day8/re-frame) application designed to ... well, that part is up to you.
+A [re-frame](https://github.com/Day8/re-frame) application designed to ... well,
+that part is up to you.
 
 ## Development Mode
 
-### Compile css:
+### Compile css
 
 Compile css file once.
 
-```
-lein less once
-```
+    lein less once
 
 Automatically recompile css file on change.
 
-```
-lein less auto
-```
+    lein less auto
 
-### Run application:
+### Run the application
 
-```
-lein clean
-rlwrap lein figwheel dev
-```
+You can run from the command line, or from within the Cursive Clojure IDE
+(recommended).
 
-Figwheel will automatically push cljs changes to the browser.
+##### From the command line
+
+Make sure your current directory is the one containing this file, then run the
+following from the command line. This assumes you have `lein` and `rlwrap`
+installed:
+
+    lein clean
+    script/figwheel-repl.sh
+
+Figwheel will automatically push ClojureScript changes to the browser.
 
 Wait a bit, then browse to [http://localhost:4000](http://localhost:4000).
 
-### Run tests:
+##### From Cursive/IntelliJ IDEA
 
-```
-lein clean
-lein doo phantom test once
-```
+Create a _clojure.main_ Cursive REPL Configuration:
+
+- Click **Run -> Edit** configurations.
+- Click the **+** button at the top left and choose **Clojure REPL**.
+- Choose **Local**.
+- Enter a name in the **Name** field (e.g., `Figwheel REPL`).
+- Choose the radio button **Use clojure.main in normal JVM process**.
+- In the **Parameters** field put `script/repl.clj`.
+- Click the **OK** button to save your REPL config.
+
+Now you can start up the app and REPL with Figwheel any time:
+
+- Go to **Run -> Debug...**, then select your REPL config ("Figwheel REPL",
+  above). The Cursive REPL tool window will appear.
+- Wait a bit, then browse to [http://localhost:4000](http://localhost:4000).
+
+Back in IntelliJ, in the tool window you should see something like this:
+
+    ...
+     Results: Stored in vars *1, *2, *3, *e holds last exception object
+    Prompt will show when Figwheel connects to your application
+    #object[Error Error: 401: Unauthorized]
+    To quit, type: :cljs/quit
+    cljs.user=> 
+    
+Now, when you modify and save a .cljs file, Figwheel will notice it and
+automatically reload it. You can experiment at the REPL by entering text at the
+bottom of the Cursive REPL tool window.
+
+### Run tests
+
+    lein clean
+    lein doo phantom test once
 
 The above command assumes that you have [phantomjs](https://www.npmjs.com/package/phantomjs) installed. However, please note that [doo](https://github.com/bensu/doo) can be configured to run cljs.test in many other JS environments (chrome, ie, safari, opera, slimer, node, rhino, or nashorn).
 
 ## Production Build
 
-```
-lein clean
-lein uberjar
-```
+    lein clean
+    lein uberjar
 
 That should compile the clojurescript code first, and then create the standalone jar.
 
@@ -52,7 +83,5 @@ If it's not set, it will run on port 3000 by default.
 
 If you only want to compile the clojurescript code:
 
-```
-lein clean
-lein cljsbuild once min
-```
+    lein clean
+    lein cljsbuild once min

--- a/project.clj
+++ b/project.clj
@@ -12,17 +12,15 @@
                  [cljs-ajax "0.5.4"]
                  [cljsjs/auth0-lock "8.1.5-1"]
                  [reagent-utils "0.1.7"]
-                 [devcards "0.2.1-7"]]
-
-
-
+                 [devcards "0.2.1-7"]
+                 [figwheel-sidecar "0.5.4-7"]]
 
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-less "1.7.5"]]
 
   :min-lein-version "2.5.3"
 
-  :source-paths ["src/clj"]
+  :source-paths ["src/clj" "script"]
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"
                                     "test/js"]
@@ -38,8 +36,7 @@
   {:dev
    {:dependencies []
 
-    :plugins      [[lein-figwheel "0.5.4-3"]
-                   [lein-doo "0.1.6"]]}}
+    :plugins      [[lein-doo "0.1.6"]]}}
 
 
   :cljsbuild
@@ -53,8 +50,6 @@
                     :asset-path           "js/compiled/out"
                     :source-map-timestamp true}}
 
-
-
     {:id           "min"
      :source-paths ["src/cljs"]
      :jar true
@@ -63,6 +58,7 @@
                     :optimizations   :advanced
                     :closure-defines {goog.DEBUG false}
                     :pretty-print    false}}
+
     {:id           "test"
      :source-paths ["src/cljs" "test/cljs"]
      :compiler     {:output-to     "resources/public/js/compiled/test.js"

--- a/script/figwheel-repl.sh
+++ b/script/figwheel-repl.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# This script just employs Leiningen to run a Figwheel REPL server. It is run
+# from the command line to compile the ClojureScript app and run the Figwheel
+# auto-compilation and REPL environment. It is necessary because the the
+# lein-figwheel plugin is incompatible with the configuration for running
+# Figwheel in a Cursive Clojure REPL, as explained here:
+#
+# https://github.com/bhauman/lein-figwheel/wiki/Running-figwheel-in-a-Cursive-Clojure-REPL
+#
+#   -- Tyler Perkins, 08-15-2016
+#
+
+here="${0%/*}"
+
+rlwrap lein run -m clojure.main "$here/repl.clj"
+

--- a/script/repl.clj
+++ b/script/repl.clj
@@ -1,0 +1,8 @@
+; This script runs a Figwheel REPL within the Cursive environment. See
+; https://github.com/bhauman/lein-figwheel/wiki/Running-figwheel-in-a-Cursive-Clojure-REPL
+
+(use 'figwheel-sidecar.repl-api)
+
+(start-figwheel!) ;; <-- fetches configuration
+(cljs-repl)
+


### PR DESCRIPTION
Hi, David.

Here are some small changes to enable the use of the Cursive REPL tool window when running Figwheel. You then don't use the command line to start up Figwheel. For those who (sadly!) don't use Cursive, I've provided a script to start Figwheel from the command line. See the project README.md, which I've updated.

Enjoy!
    Tyler
