### PR TITLE
Defining and using new function owlet-ui.firebase/on-change-presence

### DIFF
--- a/src/cljs/owlet_ui/config.cljs
+++ b/src/cljs/owlet_ui/config.cljs
@@ -34,8 +34,8 @@
 (defonce library-space-id "c7i369745nqp")
 
 (defonce firebase-app-init
-         {:apiKey        "AIzaSyD96QBAD_PtvTDrlhOYomxHW5mAvViluIQ"
-          :authDomain    "popping-inferno-468.firebaseapp.com"
-          :databaseURL   "https://popping-inferno-468.firebaseio.com"
-          :storageBucket "popping-inferno-468.appspot.com"})
+         {:apiKey        "AIzaSyAbs6wXxPGX-8XEWR6nyj7iCETOL6dZjzY"
+          :authDomain    "owlet-users.firebaseapp.com"
+          :databaseURL   "https://owlet-users.firebaseio.com"
+          :storageBucket "owlet-users.appspot.com"})
 

--- a/src/cljs/owlet_ui/firebase.cljs
+++ b/src/cljs/owlet_ui/firebase.cljs
@@ -1,12 +1,21 @@
 (ns owlet-ui.firebase
+  ;           (                           )
+  ;           )\ )   (    (       (    ( /(      )          (
+  ;          (()/(   )\   )(     ))\   )\())  ( /(   (     ))\
+  ;           /(_)) ((_) (()\   /((_) ((_)\   )(_))  )\   /((_)
+  ;          (_) _|  (_)  ((_) (_))   | |(_) ((_)_  ((_) (_))
+  ;           |  _|  | | | '_| / -_)  | '_ \ / _` | (_-< / -_)
+  ;           |_|    |_| |_|   \___|  |_.__/ \__,_| /__/ \___|
+  ;
   "Utilities for working with the Firebase backend-as-a-service platform.
-  See https://firebase.google.com"
+  See https://firebase.google.com
+  "
   (:require [owlet-ui.config :refer [firebase-app-init]]
             [owlet-ui.async :refer [repeatedly-running]]
             [reagent.ratom :refer-macros [reaction]]
             [re-frame.core :as re]
 
-            ; Add <script src="https://www.gstatic.com/firebasejs/3.4.0/firebase.js"></script>
+            ; Adds <script src="https://www.gstatic.com/firebasejs/3.4.0/firebase.js"></script>
             ; to index.html . This is required for def. of js/firebase, etc.
             [cljsjs.firebase]))
 


### PR DESCRIPTION
Hi, David.

This branch defines new function on-change-presence, which tracks the client's
connection to Firebase. It also employs the function in handler :get-auth0-profile
to save presence info in app-db at [:users user-id]. You should be able to merge
it with no problems.

Note that although handler :get-auth0-profile is the correct place for using
on-change-presence, independently, the login process itself has not been working
properly. The handler is not always invoked when it should be. I'll look into this
in the course of evaluating Firebase login, #90.

-- Tyler
