### PR TITLE
Fixed error-throwing bug in owlet-ui.firebase/upload-file.

### DIFF
--- a/src/cljs/owlet_ui/firebase.cljs
+++ b/src/cljs/owlet_ui/firebase.cljs
@@ -302,10 +302,7 @@
              (dissoc :into-dir :complete-with-snapshot)   ; Keys not expected by .on.
              (conj (when (not error) default-error))
              (conj (when complete-with-snapshot snap-complete))
-             clj->js)
-         #(println "owlet-ui.firebase/upload-file"
-                   "calling firebase.storage.UploadTask's .on():\n"
-                   (.toString %)))))
+             clj->js))))
 
 
 (defn delete-file-at-url


### PR DESCRIPTION
David, here's the fix for that regression in upload-file. It just amounts to removing the last three lines of the function!
