### PR TITLE
calls zadenMagic2 from activity-thumbnail, track-component, and activity-view

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -15,6 +15,10 @@ h1 {
   margin-top: 10px;
 }
 
+.row {
+  margin: 0;
+}
+
 #lpsidebar {
   text-align: center;
   background-color: @purple;

--- a/less/site.less
+++ b/less/site.less
@@ -199,6 +199,7 @@ mark.white {
 
 .content {
   width: 100%;
+  overflow-y: auto;
 }
 
 /* tracks view */

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -33,9 +33,8 @@
     var elementHeight = document.documentElement.clientHeight;
     if(heightClass) {
       var heightWrapHeight = heightClass.clientHeight;
-      var heightWrapHeightWithPad = heightWrapHeight + 100;
       if(heightWrapHeight > elementHeight) {
-        main.setAttribute('style', 'height:' + heightWrapHeightWithPad + 'px;');
+        main.setAttribute('style', 'height:' + heightWrapHeight + 'px;');
         console.log(heightWrapHeight);
       } else {
         main.setAttribute('style', 'height:' + elementHeight + 'px;');

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -25,24 +25,27 @@
       }
     }
   }
+</script>
+<script>
   function zadenMagic2() {
     var main = document.getElementById('main');
     var heightClass = document.getElementsByClassName('height-wrap')[0];
     var elementHeight = document.documentElement.clientHeight;
     if(heightClass) {
       var heightWrapHeight = heightClass.clientHeight;
+      var heightWrapHeightWithPad = heightWrapHeight + 100;
       if(heightWrapHeight > elementHeight) {
-        main.setAttribute('style', 'height:' + heightWrapHeight + 'px;');
+        main.setAttribute('style', 'height:' + heightWrapHeightWithPad + 'px !important;');
         console.log(heightWrapHeight);
       } else {
-        main.setAttribute('style', 'height:' + elementHeight + 'px;');
+        main.setAttribute('style', 'height:' + elementHeight + 'px !important;');
         console.log(elementHeight);
       }
-  } else {
-    main.setAttribute('style', 'height:' + elementHeight + 'px;');
-    console.log(elementHeight);
+    } else {
+      main.setAttribute('style', 'height:' + elementHeight + 'px !important;');
+      console.log(elementHeight);
+    }
   }
-}
 </script>
 </body>
 </html>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -35,14 +35,14 @@
       var heightWrapHeight = heightClass.clientHeight;
       var heightWrapHeightWithPad = heightWrapHeight + 100;
       if(heightWrapHeight > elementHeight) {
-        main.setAttribute('style', 'height:' + heightWrapHeightWithPad + 'px !important;');
+        main.setAttribute('style', 'height:' + heightWrapHeightWithPad + 'px;');
         console.log(heightWrapHeight);
       } else {
-        main.setAttribute('style', 'height:' + elementHeight + 'px !important;');
+        main.setAttribute('style', 'height:' + elementHeight + 'px;');
         console.log(elementHeight);
       }
     } else {
-      main.setAttribute('style', 'height:' + elementHeight + 'px !important;');
+      main.setAttribute('style', 'height:' + elementHeight + 'px;');
       console.log(elementHeight);
     }
   }

--- a/src/cljs/owlet_ui/components/activity_thumbnail.cljs
+++ b/src/cljs/owlet_ui/components/activity_thumbnail.cljs
@@ -1,13 +1,19 @@
-(ns owlet-ui.components.activity-thumbnail)
+(ns owlet-ui.components.activity-thumbnail
+  (:require [reagent.core :as reagent]))
 
 (defn activity-thumbnail [fields url]
   (let [image (get-in fields [:preview :sys :url])
         {:keys [title track-id summary]} fields]
-    (fn []
-      [:div.col-lg-4.col-sm-6.col-xs-12
-        [:div.activity-thumbnail-wrap.box-shadow
-          [:a {:href (str "#/tracks/" track-id "/" url)}
-            [:div.activity-thumbnail {:style {:background-image (str "url('" image "')")
-                                              :background-size "cover"}}
-              [:mark.title title]]]
-          [:div.summary summary]]])))
+    (reagent/create-class
+      {:component-did-mount
+        (fn []
+          (js/zadenMagic2))
+       :reagent-render
+        (fn []
+          [:div.col-lg-4.col-sm-6.col-xs-12
+            [:div.activity-thumbnail-wrap.box-shadow
+              [:a {:href (str "#/tracks/" track-id "/" url)}
+                [:div.activity-thumbnail {:style {:background-image (str "url('" image "')")
+                                                  :background-size "cover"}}
+                  [:mark.title title]]]
+              [:div.summary summary]]])})))

--- a/src/cljs/owlet_ui/components/track.cljs
+++ b/src/cljs/owlet_ui/components/track.cljs
@@ -8,7 +8,8 @@
     (reagent/create-class
       {:component-did-mount
        (fn []
-         (js/zadenMagic))
+         (js/zadenMagic)
+         (js/zadenMagic2))
        :reagent-render
        (fn []
          (let [name (str/upper-case (:name data))

--- a/src/cljs/owlet_ui/views/activity.cljs
+++ b/src/cljs/owlet_ui/views/activity.cljs
@@ -4,21 +4,27 @@
             [owlet-ui.components.activity.embed :refer [activity-embed]]
             [owlet-ui.components.activity.info :refer [activity-info]]
             [owlet-ui.components.activity.inspiration :refer [activity-inspiration]]
-            [owlet-ui.components.activity.reflection :refer [activity-reflection]]))
+            [owlet-ui.components.activity.reflection :refer [activity-reflection]]
+            [reagent.core :as reagent]))
 
 (defn activity-view []
-  (fn []
-    [:div.activity
-      [back-track]
-      [:div.activity-wrap
-        [:div.activity-header.col-xs-12
-          [activity-title]]
-        [:div.activity-content.col-xs-12.col-lg-8
-          [activity-embed]
-          [:div.hidden-sm-down
-            [activity-reflection]]]
-        [:div.activity-content.col-xs-12.col-lg-4
-          [activity-info]
-          [:div.hidden-md-up
-            [activity-reflection]]
-          [activity-inspiration]]]]))
+  (reagent/create-class
+    {:component-did-mount
+      (fn []
+        (js/zadenMagic2))
+     :reagent-render
+      (fn []
+        [:div.height-wrap.activity.row
+          [back-track]
+          [:div.activity-wrap
+            [:div.activity-header.col-xs-12
+              [activity-title]]
+            [:div.activity-content.col-xs-12.col-lg-8
+              [activity-embed]
+              [:div.hidden-sm-down
+                [activity-reflection]]]
+            [:div.activity-content.col-xs-12.col-lg-4
+              [activity-info]
+              [:div.hidden-md-up
+                [activity-reflection]]
+              [activity-inspiration]]]])}))

--- a/src/cljs/owlet_ui/views/activity.cljs
+++ b/src/cljs/owlet_ui/views/activity.cljs
@@ -14,7 +14,7 @@
         (js/zadenMagic2))
      :reagent-render
       (fn []
-        [:div.height-wrap.activity.row
+        [:div.height-wrap.activity
           [back-track]
           [:div.activity-wrap
             [:div.activity-header.col-xs-12

--- a/src/cljs/owlet_ui/views/track_activities.cljs
+++ b/src/cljs/owlet_ui/views/track_activities.cljs
@@ -27,7 +27,7 @@
                 [:h2 [:mark.white.box-shadow [:b display-name]]]
                 [:div.flexcontainer-wrap
                   (if (empty? activity-items)
-                   [:p.no-activities "No activities in this track yet. Check back soon."]
+                   [:p.no-activities [:mark "No activities in this track yet. Check back soon."]]
                    (for [activity activity-items
                          :let [fields (:fields activity)
                                id (get-in fields [:preview :sys :id])

--- a/src/cljs/owlet_ui/views/tracks.cljs
+++ b/src/cljs/owlet_ui/views/tracks.cljs
@@ -15,7 +15,7 @@
          (re/dispatch [:get-activity-models]))
        :reagent-render
        (fn []
-         [:div
+         [:div.height-wrap.row
            [:div.tracks
             [:h1#title [:mark "Get started by choosing a track below"]]
             [:br]

--- a/src/cljs/owlet_ui/views/tracks.cljs
+++ b/src/cljs/owlet_ui/views/tracks.cljs
@@ -15,7 +15,7 @@
          (re/dispatch [:get-activity-models]))
        :reagent-render
        (fn []
-         [:div.height-wrap.row
+         [:div.height-wrap
            [:div.tracks
             [:h1#title [:mark "Get started by choosing a track below"]]
             [:br]


### PR DESCRIPTION
Proposed changes:
- calls zadenMagic2 from `activity-thumbnail`, `track-component`, and `activity-view`
- adds `<mark>` to "no activities yet" (better visibility)
- ~~edits zadenMagic2~~
  - ~~adds 100px to `heightWrapHeight` because of `.tracks` margins -- `.height-wrap` starts lower down and isn't tall enough at small breakpoint~~ 
  - UPDATE: `overflow-y: auto` fixes this

Bugs:
- ~~for `activity-view` with overflow content, background only sizes correctly on 2nd time visit~~
  - UPDATE: `overflow-y: auto` fixes this