### PR TITLE
Dirac DevTools support without sacrificing Figwheel goodness!

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,8 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.8.51"]
                  [reagent "0.6.0"]
-                 [binaryage/devtools "0.6.1"]
+                 [binaryage/devtools "RELEASE"]
+                 [binaryage/dirac "RELEASE"]
                  [re-frame "0.7.0"]
                  [secretary "1.2.3"]
                  [compojure "1.5.0"]
@@ -12,7 +13,6 @@
                  [cljs-ajax "0.5.4"]
                  [cljsjs/auth0-lock "10.2.1-0"]
                  [reagent-utils "0.1.7"]
-                 [figwheel-sidecar "0.5.4-7"]
                  [cljsjs/bootstrap "3.3.6-1"]
                  [cljsjs/firebase "3.2.1-0"]
                  [cljsjs/marked "0.3.5-0"]
@@ -40,10 +40,53 @@
 
   :profiles
   {:dev
-   {:dependencies []
+   {:dependencies [[figwheel-sidecar "0.5.8"]]
+    :source-paths ["src/cljs" "test/cljs"]  ; Needed to run Figwheel from nrepl.
+    :plugins      [[lein-doo "0.1.6"]]}
 
-    :plugins      [[lein-doo "0.1.6"]]}}
+   :repl
+   {:repl-options {:port 8230}}
 
+   :figwheel    ; Abitrary key, used in `lein with-profile +figwheel repl`.
+   {:dependencies [[com.cemerick/piggieback "0.2.1"]]  ; Needed by cljs-repl
+    :repl-options {:nrepl-middleware
+                   [cemerick.piggieback/wrap-cljs-repl]
+
+                   :timeout
+                   180000
+
+                   :init
+                   (do (require 'figwheel-sidecar.repl-api)
+                       (figwheel-sidecar.repl-api/start-figwheel!))
+
+                   :welcome
+                   (do (println "\n\n                --- Using the Figwheel REPL --\n")
+                       (println "This is a ClojureScript REPL, not Clojure. For a Clojure REPL, enter :cljs/quit")
+                       (println "\n                ---          Enjoy!         --\n\n")
+                       (figwheel-sidecar.repl-api/cljs-repl))}}
+
+   :dirac       ; Abitrary key, used in `lein with-profile +dirac repl`.
+   {:repl-options {:nrepl-middleware
+                   [dirac.nrepl/middleware]
+
+                   :timeout
+                   180000
+
+                   :init
+                   (do (require 'figwheel-sidecar.repl-api)
+                       (figwheel-sidecar.repl-api/start-figwheel!)
+                       (require 'dirac.agent)
+                       (dirac.agent/boot!))
+
+                   :welcome
+                   (do (println "\n\n                --- Using the Dirac DevTools REPL --\n")
+                       (println "This is a Clojure REPL, not ClojureScript. For a ClojureScript REPL, open")
+                       (println "http://localhost:4000/ in Chrome Canary with extension Dirac DevTools installed.")
+                       (println "Now click the Dirac DevTools icon to the right of the address bar.")
+                       (println "Do NOT use the regular Chrome DevTools (\"Developer Tools\", Cmd-Opt-I).")
+                       (println "You can then also join that browser REPL session here at this command line")
+                       (println "by evaluating (dirac! :join) at the prompt below.")
+                       (println "\n                ---             Enjoy!            --\n\n"))}}}
 
   :cljsbuild
   {:builds

--- a/script/figwheel-repl.sh
+++ b/script/figwheel-repl.sh
@@ -1,16 +1,52 @@
 #!/usr/bin/env bash
 #
-# This script just employs Leiningen to run a Figwheel REPL server. It is run
-# from the command line to compile the ClojureScript app and run the Figwheel
-# auto-compilation and REPL environment. It is necessary because the the
-# lein-figwheel plugin is incompatible with the configuration for running
-# Figwheel in a Cursive Clojure REPL, as explained here:
 #
-# https://github.com/bhauman/lein-figwheel/wiki/Running-figwheel-in-a-Cursive-Clojure-REPL
-#
-#   -- Tyler Perkins, 08-15-2016
+#   -- Tyler Perkins, 12-30-2016
 #
 
-here="${0%/*}"
+USAGE="
+Usage:  $0 [--][no-readline | no-clean | dirac | help] ...
 
-lein clean && rlwrap lein run -m clojure.main "$here/repl.clj"
+        This script just employs Leiningen to run a Figwheel REPL server.
+        It is run from a terminal command line to compile and start the Owlet
+        ClojureScript app and run the Figwheel auto-compilation and REPL
+        environment in the terminal. By default, a clean rebuild is performed,
+        and rlwrap is used to provide readline editing at the REPL.
+
+        If the --dirac option is provided, Figwheel will still run Owlet and
+        reload modified code, but instead of the Figwheel REPL in the terminal,
+        a Dirac server is started instead. Now just click the Dirac DevTools
+        icon to the right of the address bar in Chrome Canary to get the REPL
+        window. See https://github.com/binaryage/dirac
+
+        All this works using a Clojure nREPL on port 8230. You can connect to
+        it with another client, say an IDE, to get a Clojure, not ClojureScript
+        REPL. To then obtain a ClojureScript REPL from within that Clojure
+        REPL, evaluate (figwheel-sidecar.repl-api/cljs-repl). If you provided
+        the --dirac option, instead evaluate (dirac! :join)."
+
+maybe_rlwrap='rlwrap'
+maybe_clean='do clean,'
+profile='+figwheel'
+
+for opt in $@; do
+    case ${opt#--} in
+      no-readline)
+        maybe_rlwrap=''
+        ;;
+      no-clean)
+        maybe_clean=''
+        ;;
+      dirac)
+        profile='+dirac'
+        ;;
+      *)
+        echo "$USAGE"
+        exit 0
+        ;;
+    esac
+done
+
+echo "$maybe_rlwrap lein $maybe_clean with-profile $profile repl"
+$maybe_rlwrap lein $maybe_clean with-profile $profile repl
+

--- a/script/repl.clj
+++ b/script/repl.clj
@@ -1,8 +1,0 @@
-; This script runs a Figwheel REPL within the Cursive environment. See
-; https://github.com/bhauman/lein-figwheel/wiki/Running-figwheel-in-a-Cursive-Clojure-REPL
-
-(use 'figwheel-sidecar.repl-api)
-
-(start-figwheel!) ;; <-- fetches configuration
-(cljs-repl)
-

--- a/script/start-chrome-canary.sh
+++ b/script/start-chrome-canary.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+#   This script just starts up the owlet-ui app in Chrome Canary for debugging
+#   with Dirac in MacOS.
+#
+
+chrome='/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary'
+page='http://localhost:4000/'
+user_data_dir='.dirac-chrome-profile'
+
+test -f "$chrome"  ||  {
+    echo 'See https://github.com/binaryage/dirac-sample/blob/master/readme.md'
+    echo 'Google Chrome Canary must be installed. It is available here:'
+    echo 'https://www.google.com/chrome/browser/canary.html'
+    exit 1
+}
+
+test -d "$user_data_dir"  ||  mkdir "$user_data_dir"
+
+echo "Launching Chrome Canary for $page"  &&  (     \
+    "$chrome"                                       \
+      --remote-debugging-port=9222                  \
+      --no-first-run                                \
+      --user-data-dir="$user_data_dir"              \
+      "$page"                                       \
+      2>"$user_data_dir/cmd-line.log"               \
+    ||                                              \
+    cat .dirac-chrome-profile/cmd-line.log          \
+) &
+

--- a/src/cljs/owlet_ui/core.cljs
+++ b/src/cljs/owlet_ui/core.cljs
@@ -2,6 +2,7 @@
     (:require [reagent.core :as reagent]
               [re-frame.core :as re-frame]
               [devtools.core :as devtools]
+              [dirac.runtime :as dirac]
               [owlet-ui.handlers]
               [owlet-ui.subs]
               [owlet-ui.routes :as routes]
@@ -11,7 +12,8 @@
 (defn dev-setup []
   (when config/debug?
     (println "dev mode")
-    (devtools/install!)))
+    (devtools/install!)
+    (dirac/install!)))
 
 (defn mount-root []
   (reagent/render [app/main-view]


### PR DESCRIPTION
This branch adds support for the awsome **Dirac DevTools**, which provides a ClojureScript REPL _**and debugging tools**_ within the Chrome Canary browser.