### PR TITLE
Fix re-frame upgrade

### DIFF
--- a/src/cljs/owlet_ui/subs.cljs
+++ b/src/cljs/owlet_ui/subs.cljs
@@ -1,6 +1,5 @@
 (ns owlet-ui.subs
-  (:require [re-frame.core :as re])
-  (:require-macros [reagent.ratom :refer [reaction]]))
+  (:require [re-frame.core :as re]))
 
 
 (defn register-getter-sub
@@ -36,8 +35,7 @@
      (fn [db _ & args]
        (-> db
            (get-in db-path)
-           (#(apply f % args))
-           reaction)))))
+           (#(apply f % args)))))))
 
 (re/reg-sub
   :active-view


### PR DESCRIPTION
Tests broke in `owlet-ui/firebase-test` after the recent upgrade to re-frame  0.9.1. Now, `re-frame/reg-sub` takes a function that shoud NOT return a reaction as was required previously. The fix just required a small change to `owlet-ui.subs/register-getter-sub`.