### PR TITLE
Refactor branches component

### DIFF
--- a/src/cljs/owlet_ui/components/branch.cljs
+++ b/src/cljs/owlet_ui/components/branch.cljs
@@ -4,42 +4,51 @@
             [reagent.core :as reagent :refer [atom]]
             [camel-snake-kebab.core :refer [->kebab-case]]))
 
-(def hover-image (reagent/atom ""))
-
-(defn get-random [images]
-  (get images (rand-int (count images))))
-
-(defn set-hover [images]
-  (let [image (get-random images)]
-    (if (> (count images) 1)
-      ; prevent the same image twice in a row
-      (if (== image @hover-image)
-        (set-hover images)
-        (reset! hover-image image))
-      (reset! hover-image image))))
 
 (defn branch [[color branch-name] branch-key]
- (let [activities-by-branch (re/subscribe [:activities-by-branch])]
-  (let [name (str/upper-case branch-name)
-        name-line1 (first (str/split name " "))
-        name-line2 (rest (str/split name " "))
-        counter (-> @activities-by-branch
-                    branch-key
-                    :count)
-        preview-images (-> @activities-by-branch
-                           branch-key
-                           :preview-urls)]
-    [:div.branchwrapper.col-xs-12.col-md-6.col-lg-4
-     [:div.branchwrap {:style {:background-image (str "url('" @hover-image "')")}
-                       :on-mouse-enter #(set-hover preview-images)}
-      [:div.branch-bg.box-shadow {:style {:background-color color
-                                          :background-image (str "linear-gradient(to right, " color " 25%, rgba(0,0,0,0) 75%")}}
-       [:a.branch {:on-click #(re/dispatch-sync [:set-activities-by-branch-in-view (->kebab-case branch-name)])
-                   :href     (str "#/" (->kebab-case branch-name))}
-        [:h2 [:mark name-line1]
-         (when (<= 1 (count name-line2))
-           [:span
-            [:br]
-            [:mark (str/join " " name-line2)]])]
-        [:div.counter
-         [:p counter]]]]]])))
+  (let [lines       (str/split (str/upper-case branch-name) " ")
+        name-line1  (first lines)
+        name-line2  (rest lines)
+        hover-image (reagent/atom "")
+        set-hover!  (fn [images]
+                      ; Changes hover-image to a new, random URL, if avail.
+                      (reset! hover-image
+                              (-> images
+                                  (disj @hover-image)
+                                  seq
+                                  rand-nth
+                                  (or @hover-image))))
+        activities-by-branch
+                    (re/subscribe [:activities-by-branch])]
+    (fn []
+      ; Form-2 component needed so hover-image atom is not redefined on
+      ; every render.
+      (let [counter        (-> @activities-by-branch
+                               branch-key
+                               :count)
+            preview-images (-> @activities-by-branch
+                               branch-key
+                               :preview-urls
+                               set)]
+        [:div.branchwrapper.col-xs-12.col-md-6.col-lg-4
+         [:div.branchwrap {:style {:background-image (str "url('"
+                                                          @hover-image
+                                                          "')")}
+                           :on-mouse-enter #(set-hover! preview-images)}
+          [:div.branch-bg.box-shadow
+           {:style {:background-color color
+                    :background-image (str "linear-gradient(to right, "
+                                           color
+                                           " 25%, rgba(0,0,0,0) 75%")}}
+           [:a.branch {:on-click #(re/dispatch-sync
+                                   [:set-activities-by-branch-in-view
+                                    (->kebab-case branch-name)])
+                       :href     (str "#/" (->kebab-case branch-name))}
+            [:h2 [:mark name-line1]
+             (when (<= 1 (count name-line2))
+               [:span
+                [:br]
+                [:mark (str/join " " name-line2)]])]
+            [:div.counter
+             [:p counter]]]]]]))))
+


### PR DESCRIPTION
Two main changes:

- Local state `hover-image` now resides in the `branch` function, consistent with Reagent best practice.

- Simplified function `set-hover` and, as above, limited its scope to `branch`.
