### PR TITLE
Converts lpsidebar functions to ClojureScript

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -26,38 +26,5 @@
 <script src="js/compiled/app.js"></script>
 <script>owlet_ui.core.init();</script>
 <script src="js/vendor/initPhotoSwipeFromDOM.js"></script>
-<script async defer>
-  function openSidebar() {
-    var content = document.getElementsByClassName("content");
-    var sidebarWrap = document.getElementById("lpsidebar-wrap");
-    var sidebar = document.getElementById("lpsidebar");
-    var open = document.getElementById("lpsidebar-open");
-    var close = document.getElementById("lpsidebar-close");
-    var overlay = document.getElementById("lpsidebar-overlay");
-    sidebarWrap.style.width = "80px";
-    sidebar.style.width = "80px";
-    open.style.left = "80px";
-    open.style.zIndex = "0";
-    close.style.left = "80px";
-    close.style.zIndex = "2";
-    overlay.style.backgroundColor = "rgba(0,0,0,0.5)";
-    overlay.style.zIndex = "2";
-  }
-  function closeSidebar() {
-    var sidebarWrap = document.getElementById("lpsidebar-wrap");
-    var sidebar = document.getElementById("lpsidebar");
-    var open = document.getElementById("lpsidebar-open");
-    var close = document.getElementById("lpsidebar-close");
-    var overlay = document.getElementById("lpsidebar-overlay");
-    sidebarWrap.style.width = "0px";
-    sidebar.style.width = "0px";
-    open.style.left = "0px";
-    open.style.zIndex = "3";
-    close.style.left = "0px";
-    close.style.zIndex = "0";
-    overlay.style.backgroundColor = "rgba(0,0,0,0)";
-    overlay.style.zIndex = "-1";
-  }
-</script>
 </body>
 </html>

--- a/src/cljs/owlet_ui/app.cljs
+++ b/src/cljs/owlet_ui/app.cljs
@@ -52,9 +52,7 @@
         (set! (-> close .-style .-zIndex) "0")
         (set! (-> overlay .-style .-backgroundColor) "rgba(0,0,0,0)")
         (set! (-> overlay .-style .-zIndex) "-1")))))
-
-(set! js/toggle-sidebar toggle-sidebar)
-
+        
 (def show? (reagent/atom false))
 
 (defn main-view []
@@ -73,13 +71,13 @@
          (if (= @active-view :welcome-view)
            [show-view @active-view]
            [:div#main
-            [:div#lpsidebar-overlay.hidden-md-up {:on-click (js/toggle-sidebar false)}]
+            [:div#lpsidebar-overlay.hidden-md-up {:on-click (toggle-sidebar false)}]
             [:div#lpsidebar-wrap.hidden-md-up
              [lpsidebar-component]]
             [:img#lpsidebar-open.hidden-md-up {:src "img/owlet-tab-closed.png"
-                                               :on-click (js/toggle-sidebar true)}]
+                                               :on-click (toggle-sidebar true)}]
             [:img#lpsidebar-close.hidden-md-up {:src "img/owlet-tab-opened.png"
-                                                :on-click (js/toggle-sidebar false)
+                                                :on-click (toggle-sidebar false)
                                                 :style {:z-index "0"}}]
             [:div#sidebar-wrap.hidden-sm-down
              [sidebar-component]]

--- a/src/cljs/owlet_ui/app.cljs
+++ b/src/cljs/owlet_ui/app.cljs
@@ -27,6 +27,34 @@
 (defn show-view [view-name]
   [views view-name])
 
+(defn toggle-sidebar [closed]
+  (let [sidebar-wrap (js->clj (js/document.getElementById "lpsidebar-wrap"))
+        sidebar (js->clj (js/document.getElementById "lpsidebar"))
+        open (js->clj (js/document.getElementById "lpsidebar-open"))
+        close (js->clj (js/document.getElementById "lpsidebar-close"))
+        overlay (js->clj (js/document.getElementById "lpsidebar-overlay"))]
+    (if (= true closed)
+      (fn []
+        (set! (-> sidebar-wrap .-style .-width) "80px")
+        (set! (-> sidebar .-style .-width) "80px")
+        (set! (-> open .-style .-left) "80px")
+        (set! (-> open .-style .-zIndex) "0")
+        (set! (-> close .-style .-left) "80px")
+        (set! (-> close .-style .-zIndex) "2")
+        (set! (-> overlay .-style .-backgroundColor) "rgba(0,0,0,0.5)")
+        (set! (-> overlay .-style .-zIndex) "2"))
+      (fn []
+        (set! (-> sidebar-wrap .-style .-width) "0px")
+        (set! (-> sidebar .-style .-width) "0px")
+        (set! (-> open .-style .-left) "0px")
+        (set! (-> open .-style .-zIndex) "3")
+        (set! (-> close .-style .-left) "0px")
+        (set! (-> close .-style .-zIndex) "0")
+        (set! (-> overlay .-style .-backgroundColor) "rgba(0,0,0,0)")
+        (set! (-> overlay .-style .-zIndex) "-1")))))
+
+(set! js/toggle-sidebar toggle-sidebar)
+
 (def show? (reagent/atom false))
 
 (defn main-view []
@@ -45,13 +73,13 @@
          (if (= @active-view :welcome-view)
            [show-view @active-view]
            [:div#main
-            [:div#lpsidebar-overlay.hidden-md-up {:on-click #(js/closeSidebar)}]
+            [:div#lpsidebar-overlay.hidden-md-up {:on-click (js/toggle-sidebar false)}]
             [:div#lpsidebar-wrap.hidden-md-up
              [lpsidebar-component]]
             [:img#lpsidebar-open.hidden-md-up {:src "img/owlet-tab-closed.png"
-                                               :on-click #(js/openSidebar)}]
+                                               :on-click (js/toggle-sidebar true)}]
             [:img#lpsidebar-close.hidden-md-up {:src "img/owlet-tab-opened.png"
-                                                :on-click #(js/closeSidebar)
+                                                :on-click (js/toggle-sidebar false)
                                                 :style {:z-index "0"}}]
             [:div#sidebar-wrap.hidden-sm-down
              [sidebar-component]]

--- a/src/cljs/owlet_ui/events.cljs
+++ b/src/cljs/owlet_ui/events.cljs
@@ -7,7 +7,8 @@
             [owlet-ui.helpers :refer [keywordize-name remove-nil
                                       parse-platform clean-search-term]]
             [day8.re-frame.http-fx]
-            [ajax.core :as ajax :refer [GET POST PUT]]))
+            [ajax.core :as ajax :refer [GET POST PUT]]
+            [owlet-ui.app :refer [toggle-sidebar]]))
 
 
 (defonce library-content-url
@@ -33,7 +34,7 @@
   (fn [cofx]
     (let [db (:db cofx)]
       (when-not (= (db :active-view) :welcome-view)
-        (js/toggle-sidebar false))
+        (toggle-sidebar false))
       (assoc-in cofx [:db :app :open-sidebar] true))))
 
 

--- a/src/cljs/owlet_ui/events.cljs
+++ b/src/cljs/owlet_ui/events.cljs
@@ -33,7 +33,7 @@
   (fn [cofx]
     (let [db (:db cofx)]
       (when-not (= (db :active-view) :welcome-view)
-        (js/closeSidebar))
+        (js/toggle-sidebar false))
       (assoc-in cofx [:db :app :open-sidebar] true))))
 
 


### PR DESCRIPTION
Converts lpsidebar open and close functions to ClojureScript to prevent "Error: closeSidebar is not defined" bug