### PR TITLE
Organize background images

### DIFF
--- a/src/cljs/owlet_ui/app.cljs
+++ b/src/cljs/owlet_ui/app.cljs
@@ -57,7 +57,6 @@
         (set! (-> overlay .-style .-backgroundColor) "rgba(0,0,0,0)")
         (set! (-> overlay .-style .-zIndex) "-1")))))
 
-(def show? (reagent/atom false))
 
 (defn main-view []
 
@@ -73,9 +72,7 @@
   (let [active-view (rf/subscribe [:active-view])
         loading? (rf/subscribe [:set-loading-state?])
         src (rf/subscribe [:my-background-image-url])
-        is-user-logged-in? (rf/subscribe [:my-identity])
-        open-modal (fn [] (reset! show? true))
-        close-modal (fn [] (reset! show? false))]
+        is-user-logged-in? (rf/subscribe [:my-identity])]
     (fn []
       (set! (-> js/document .-title) @(rf/subscribe [:app-title]))
       (if (= @active-view :welcome-view)
@@ -96,7 +93,7 @@
           [:div.inner-height-wrap
              [:div.content {:style {:background-image (str "url(" @src ")")
                                     :background-size  "cover"}}
-                [upload-image-component show? close-modal]
+                [upload-image-component]
                 [:button#change-header-btn
                  {:type     "button"
                   :class    "btn btn-secondary"
@@ -105,7 +102,7 @@
                              :display   (if @is-user-logged-in?
                                           "block"
                                           "none")}
-                  :on-click open-modal}
+                  :on-click #(rf/dispatch [:show-bg-img-upload true])}
                  [:i.fa.fa-pencil-square-o]]
                 (when @loading?
                   [loading-component])

--- a/src/cljs/owlet_ui/components/header.cljs
+++ b/src/cljs/owlet_ui/components/header.cljs
@@ -1,15 +1,13 @@
 (ns owlet-ui.components.header
   (:require [reagent.core :as reagent]
             [owlet-ui.components.upload-image-modal :refer [upload-image-component]]
-            [re-frame.core :as re-frame]))
+            [re-frame.core :as rf]))
 
 (defonce show? (reagent/atom false))
 
 (defn header-component []
-  (let [src (re-frame/subscribe [:my-background-image-url])
-        is-user-logged-in? (re-frame/subscribe [:my-identity])
-        open-modal (fn [_] (reset! show? true))
-        close-modal (fn [_] (reset! show? false))]
+  (let [src (rf/subscribe [:my-background-image-url])
+        is-user-logged-in? (rf/subscribe [:my-identity])]
     (fn []
       [:div#header {:style {:position "fixed"
                             :width "100%"
@@ -17,15 +15,15 @@
                             :background-image (str "url(" @src ")")
                             :background-size "cover"
                             :z-index "-1"}}
-       [upload-image-component show? close-modal]
+       [upload-image-component]
        [:button#change-header-btn
         {:type     "button"
          :class    "btn btn-secondary"
          :style    {:font-size "1em"
-                    :padding "6px"
-                    :z-index "10 !important"
-                    :display (if @is-user-logged-in?
-                               "block"
-                               "none")}
-         :on-click open-modal}
+                    :padding   "6px"
+                    :z-index   "10 !important"
+                    :display   (if @is-user-logged-in?
+                                 "block"
+                                 "none")}
+         :on-click (rf/dispatch [:show-bg-img-upload true])}
         [:i.fa.fa-pencil-square-o]]])))

--- a/src/cljs/owlet_ui/components/upload_image_modal.cljs
+++ b/src/cljs/owlet_ui/components/upload_image_modal.cljs
@@ -12,40 +12,46 @@
         progress-pct (r/atom 0)
         me           (rf/subscribe [:my-identity])]
     (fn []
-      [:form
-       [:b "Upload a background image file"]
-       [:br]
-       [:br]
-       [:input#upload-input-id {:type "file"}]
-       [:br]
-       [:br]
-       [:button
-        {:class    "btn btn-primary"
-         :type     "button"
-         :on-click #(fb/ez-upload-file "upload-input-id"  ; Input DOM id.
-                                       (str "users/"      ; Firebase stor. dir.
-                                            (:firebase-id @me)
-                                            "/background-image")
-                                       progress-pct       ; Tracking pct. done.
-                                       upload-error       ; Tracking any error.
-                                       :update-user-background!)}
-                                                          ; Evt. id to send URL.
-        "UPLOAD "
-        [:span.fa.fa-upload]]
-       [:br]
-       [:br]
+      (if @me        ; Uploading a file is only permitted with a :firebase-id.
+        [:form
+         [:b "Upload a background image file"]
+         [:br]
+         [:br]
+         [:input#upload-input-id {:type "file"}]
+         [:br]
+         [:br]
+         [:button
+          {:class    "btn btn-primary"
+           :type     "button"
+           :on-click #(fb/ez-upload-file "upload-input-id" ; Input DOM id.
+                                         (str "users/"     ; Firebase Strg dir.
+                                              (name (:firebase-id @me))
+                                              "/background-image")
+                                         progress-pct      ; Tracking pct done.
+                                         upload-error      ; Tracking any error.
+                                         :update-user-background!)}
+                                                           ; Evt id to send URL.
+          "UPLOAD "
+          [:span.fa.fa-upload]]
+         [:br]
+         [:br]
 
-       (if @upload-error
-         [alert-box                 ; Have error. Show its message.
-          :alert-type :warning
-          :body       @upload-error
-          :padding    "12px"]
-         [:div                      ; No error. Show progress bar.
-          [:br]
-          [progress-bar
-           :striped? true
-           :model    progress-pct
-           :width    "350px"]])])))
+         (if @upload-error
+           [alert-box                 ; Have error. Show its message.
+            :alert-type :warning
+            :body       @upload-error
+            :padding    "12px"]
+           [:div                      ; No error. Show progress bar.
+            [:br]
+            [progress-bar
+             :striped? true
+             :model    progress-pct
+             :width    "350px"]])]
+
+        [alert-box
+         :alert-type :danger
+         :body       "You must be logged in to upload a file."
+         :padding    "12px"]))))
 
 
 (defn upload-image-component

--- a/src/cljs/owlet_ui/components/upload_image_modal.cljs
+++ b/src/cljs/owlet_ui/components/upload_image_modal.cljs
@@ -6,57 +6,81 @@
     [cljsjs.jquery]
     [re-com.core :refer [v-box h-box modal-panel button alert-box progress-bar]]))
 
-(def show-upload-error (reagent/atom false))
 
 (defn handle-firebase-upload
-  [element-id close-modal progress]
-  (let [el (.getElementById js/document element-id)
-        file (aget (.-files el) 0)]
-    (try
-      (firebase/upload-file
-        file
-        :into-dir "user-background-images"
-        :next (fn [p]
-                (let [total (.-totalBytes p)
-                      transfered (.-bytesTransferred p)
-                      percentage (js/Math.round (* (/ transfered total) 100))]
-                     (reset! progress percentage)))
-        :complete-with-snapshot #(let [url (.-downloadURL %)]
-                                  (close-modal)
-                                  (re-frame/dispatch [:update-user-background! url])))
-      (catch js/Object _
-        (reset! show-upload-error true)))))
+  "Initiates the upload of the file selected in an
+  <input type=\"file\" id=input-elem-id> element in the current document,
+  where input-elem-id is the string given in the first argument. The given
+  destination directory string must be relative to the root of Firebase
+  Storage. Atom progress-pct-atom is periodically updated with the percentage
+  of uploaded bytes. Atom error-atom may be updated with a js/Error object if
+  the user did not provide a file in the input element or if there was some
+  other error in the upload.
+  "
+  [input-elem-id dest-dir close-modal progress-pct-atom error-atom]
+
+  (firebase/upload-file
+    ; JS File object, or nil if none selected:
+    (-> input-elem-id js/document.getElementById (aget "files" 0))
+
+    ; Upload options:
+    :into-dir dest-dir
+    :next     (fn [task-snapshot]
+                ; What to do after each batch of bytes has been transfered.
+                ; Argument is a firebase.storage.UploadTaskSnapshot. See
+                ; https://firebase.google.com/docs/reference/js/firebase.storage.UploadTaskSnapshot
+                (let [total      (.-totalBytes task-snapshot)
+                      transfered (.-bytesTransferred task-snapshot)]
+                  (reset! progress-pct-atom
+                          (js/Math.round (* 100 (/ transfered total))))))
+    :complete-with-snapshot
+              (fn [snapshot]
+                (let [url (.-downloadURL snapshot)]
+                  (re-frame/dispatch [:update-user-background! url])
+                  (close-modal)))
+    :error    (fn [error]
+                (reset! error-atom (.-message error)))))
 
 
-(defn upload-form [close-modal]
-  (let [error-msg "Please select a file to be uploaded."
-        progress (reagent/atom 0)]
-    [:form
-     [:b "Select Image: "]
-     [:br]
-     [:br]
-     [:input#upload-file
-      {:type "file"
-       :name "upload-file"
-       :on-change #(reset! show-upload-error false)}]
-     [:br]
-     [:br]
-     [:button {:class    "btn btn-primary" :type "button"
-               :on-click #(handle-firebase-upload "upload-file" close-modal progress)}
-      "UPLOAD " [:span.fa.fa-upload]]
-     (when @show-upload-error
-       [:div
-        [:br]
-        [alert-box
-         :alert-type :warning
-         :body       error-msg
-         :padding    "6px"]])
-     [:br]
-     [:br]
-     [progress-bar
-      :striped? true
-      :model    progress
-      :width    "350px"]]))
+(defn upload-form
+  [close-modal]
+  (let [upload-error (reagent/atom nil)
+        progress-pct (reagent/atom 0)]
+    (fn []
+      [:form
+       [:b "Upload a background image file"]
+       [:br]
+       [:br]
+       [:input#upload-file
+        {:type      "file"
+         :name      "upload-file"
+         :on-change #(reset! upload-error nil)}]
+       [:br]
+       [:br]
+       [:button
+        {:class    "btn btn-primary"
+         :type     "button"
+         :on-click #(handle-firebase-upload "upload-file"
+                                            "user-background-images"
+                                            close-modal
+                                            progress-pct
+                                            upload-error)}
+        "UPLOAD "
+        [:span.fa.fa-upload]]
+       [:br]
+       [:br]
+
+       (if @upload-error
+         [alert-box                 ; Have error. Show its message.
+          :alert-type :warning
+          :body       @upload-error
+          :padding    "12px"]
+         [:div                      ; No error. Show progress bar.
+          [:br]
+          [progress-bar
+           :striped? true
+           :model    progress-pct
+           :width    "350px"]])])))
 
 
 (defn upload-image-component [show? close-modal]

--- a/src/cljs/owlet_ui/components/upload_image_modal.cljs
+++ b/src/cljs/owlet_ui/components/upload_image_modal.cljs
@@ -9,23 +9,27 @@
 (defn upload-form
   []
   (let [upload-error (r/atom nil)
-        progress-pct (r/atom 0)]
+        progress-pct (r/atom 0)
+        me           (rf/subscribe [:my-identity])]
     (fn []
       [:form
        [:b "Upload a background image file"]
        [:br]
        [:br]
-       [:input#upload-file {:type "file"}]
+       [:input#upload-input-id {:type "file"}]
        [:br]
        [:br]
        [:button
         {:class    "btn btn-primary"
          :type     "button"
-         :on-click #(fb/ez-upload-file "upload-file"
-                                       "user-background-images"
-                                       progress-pct
-                                       upload-error
+         :on-click #(fb/ez-upload-file "upload-input-id"  ; Input DOM id.
+                                       (str "users/"      ; Firebase stor. dir.
+                                            (:firebase-id @me)
+                                            "/background-image")
+                                       progress-pct       ; Tracking pct. done.
+                                       upload-error       ; Tracking any error.
                                        :update-user-background!)}
+                                                          ; Evt. id to send URL.
         "UPLOAD "
         [:span.fa.fa-upload]]
        [:br]

--- a/src/cljs/owlet_ui/components/upload_image_modal.cljs
+++ b/src/cljs/owlet_ui/components/upload_image_modal.cljs
@@ -1,70 +1,31 @@
 (ns owlet-ui.components.upload-image-modal
   (:require
-    [reagent.core :as reagent]
-    [re-frame.core :as re-frame]
-    [owlet-ui.firebase :as firebase]
-    [cljsjs.jquery]
+    [reagent.core :as r]
+    [re-frame.core :as rf]
+    [owlet-ui.firebase :as fb]
     [re-com.core :refer [v-box h-box modal-panel button alert-box progress-bar]]))
 
 
-(defn handle-firebase-upload
-  "Initiates the upload of the file selected in an
-  <input type=\"file\" id=input-elem-id> element in the current document,
-  where input-elem-id is the string given in the first argument. The given
-  destination directory string must be relative to the root of Firebase
-  Storage. Atom progress-pct-atom is periodically updated with the percentage
-  of uploaded bytes. Atom error-atom may be updated with a js/Error object if
-  the user did not provide a file in the input element or if there was some
-  other error in the upload.
-  "
-  [input-elem-id dest-dir close-modal progress-pct-atom error-atom]
-
-  (firebase/upload-file
-    ; JS File object, or nil if none selected:
-    (-> input-elem-id js/document.getElementById (aget "files" 0))
-
-    ; Upload options:
-    :into-dir dest-dir
-    :next     (fn [task-snapshot]
-                ; What to do after each batch of bytes has been transfered.
-                ; Argument is a firebase.storage.UploadTaskSnapshot. See
-                ; https://firebase.google.com/docs/reference/js/firebase.storage.UploadTaskSnapshot
-                (let [total      (.-totalBytes task-snapshot)
-                      transfered (.-bytesTransferred task-snapshot)]
-                  (reset! progress-pct-atom
-                          (js/Math.round (* 100 (/ transfered total))))))
-    :complete-with-snapshot
-              (fn [snapshot]
-                (let [url (.-downloadURL snapshot)]
-                  (re-frame/dispatch [:update-user-background! url])
-                  (close-modal)))
-    :error    (fn [error]
-                (reset! error-atom (.-message error)))))
-
-
 (defn upload-form
-  [close-modal]
-  (let [upload-error (reagent/atom nil)
-        progress-pct (reagent/atom 0)]
+  []
+  (let [upload-error (r/atom nil)
+        progress-pct (r/atom 0)]
     (fn []
       [:form
        [:b "Upload a background image file"]
        [:br]
        [:br]
-       [:input#upload-file
-        {:type      "file"
-         :name      "upload-file"
-         :on-change #(reset! upload-error nil)}]
+       [:input#upload-file {:type "file"}]
        [:br]
        [:br]
        [:button
         {:class    "btn btn-primary"
          :type     "button"
-         :on-click #(handle-firebase-upload "upload-file"
-                                            "user-background-images"
-                                            close-modal
-                                            progress-pct
-                                            upload-error)}
+         :on-click #(fb/ez-upload-file "upload-file"
+                                       "user-background-images"
+                                       progress-pct
+                                       upload-error
+                                       :update-user-background!)}
         "UPLOAD "
         [:span.fa.fa-upload]]
        [:br]
@@ -83,16 +44,22 @@
            :width    "350px"]])])))
 
 
-(defn upload-image-component [show? close-modal]
-  (fn []
-    (when @show?
-      [v-box
-       :children [[modal-panel
-                   :backdrop-color "grey"
-                   :backdrop-opacity 0.4
-                   :child [h-box
-                           :children [[upload-form close-modal]
-                                      [button
-                                       :class "btn-secondary"
-                                       :label "x"
-                                       :on-click close-modal]]]]]])))
+(defn upload-image-component
+  []
+  (when @(rf/subscribe [:showing-bg-img-upload])
+    [v-box
+
+     :children
+     [[modal-panel
+       :backdrop-color "grey"
+       :backdrop-opacity 0.4
+
+       :child
+       [h-box
+
+        :children
+        [[upload-form]
+         [button
+          :class "btn-secondary"
+          :label "x"
+          :on-click #(rf/dispatch [:show-bg-img-upload false])]]]]]]))

--- a/src/cljs/owlet_ui/events.cljs
+++ b/src/cljs/owlet_ui/events.cljs
@@ -128,10 +128,14 @@
     (assoc db :active-view active-view)))
 
 
+(reg-setter :show-bg-img-upload [:showing-bg-img-upload])
+
+
 (re/reg-event-fx
   :update-user-background!
   (fn [{{{my-db-ref :firebase-db-ref} :my-identity} :db} [_ url]]
-    {:firebase-reset-into-ref [my-db-ref {:background-image-url url}]}))
+    {:firebase-reset-into-ref [my-db-ref {:background-image-url url}]
+     :dispatch                [:show-bg-img-upload false]}))
 
 
 (re/reg-event-fx

--- a/src/cljs/owlet_ui/firebase.cljs
+++ b/src/cljs/owlet_ui/firebase.cljs
@@ -444,6 +444,55 @@
         (js/console.log "upload-file:" err-msg)))))
 
 
+(defn ez-upload-file
+  "Provides a straightforward way for a GUI to upload a local file to Firebase
+  Storage and receive the URL pointing to the new file there.
+
+  When called, ez-upload-file initiates the upload of the file selected in an
+  <input type=\"file\" id=input-elem-id> element in the current document,
+  where input-elem-id is the string given in the first argument. The given
+  destination directory string must be relative to the root of Firebase
+  Storage. As the upload proceeds, atom progress-pct-atom is periodically
+  updated with a number: the percentage of uploaded bytes. Atom error-atom will
+  contain the nil value unless the user did not provide a file in the input
+  element or if there was some other problem preventing the upload. In this
+  case error-atom will contain an error message.
+
+  Finally, when the upload is complete, a re-frame event is dispatched, which
+  is a vector of the given event-id, the new URL string, and any provided args.
+  "
+  [input-elem-id dest-dir progress-pct-atom error-atom event-id & args]
+
+  (when progress-pct-atom (reset! progress-pct-atom 0))
+  (when error-atom        (reset! error-atom        nil))
+  (apply
+    upload-file
+
+    ; JS File object, or nil if none selected:
+    (-> input-elem-id js/document.getElementById (aget "files" 0))
+
+    ; Upload options:
+    (concat
+      [:into-dir               dest-dir
+       :complete-with-snapshot (fn [snapshot]
+                                 (->> snapshot          ; The firebase.storage.UploadTaskSnapshot
+                                      .-downloadURL     ; The new URL of the stored file.
+                                      (conj args)       ; Makes (url arg1 arg2 ...)
+                                      (into [event-id]) ; Makes [event-id url arg1 arg2 ...)
+                                      rf/dispatch))]
+      (and progress-pct-atom
+           [:next (fn [task-snapshot]
+                    ; What to do after each batch of bytes has been transfered.
+                    ; Argument is a firebase.storage.UploadTaskSnapshot. See
+                    ; https://firebase.google.com/docs/reference/js/firebase.storage.UploadTaskSnapshot
+                    (let [total      (.-totalBytes task-snapshot)
+                          transfered (.-bytesTransferred task-snapshot)]
+                      (reset! progress-pct-atom
+                              (js/Math.round (* 100 (/ transfered total))))))])
+      (and error-atom
+           [:error (fn [error]
+                     (reset! error-atom (.-message error)))]))))
+
 
 (defn delete-file-at-url
   "Returns a Promise containing void, which deletes the file at the given URL.

--- a/src/cljs/owlet_ui/subs.cljs
+++ b/src/cljs/owlet_ui/subs.cljs
@@ -47,6 +47,7 @@
 
 (reg-getter :my-identity [:my-identity])
 
+(reg-getter :showing-bg-img-upload [:showing-bg-img-upload])
 
 (rf/reg-sub
   :my-background-image-url


### PR DESCRIPTION
This closes [#195](https://github.com/codefordenver/owlet/issues/195), the issue of background images being identified only by filename, independent of user. Images are still stored in Firebase Storage, but there is now a "users" directory at the root level containing a directory for each user named by his/her social id. This is the place for all the user's stuff. (Each user directory currently contains just the directory, "background-image", which in turn contains the uploaded file. Thus, the URL for the image is something like this:

    https://firebasestorage.googleapis.com/v0/b/owlet-users.appspot.com/o/users%2F <user's social id> %2Fbackground-image%2F <image filename> ?alt=media&token= <...>