### PR TITLE
Update figwheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ out
 .lein-repl-history
 .nrepl-port
 /bin/
+
+.project

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ out
 .dirac-chrome-profile/
 .lein-repl-history
 .nrepl-port
+/bin/

--- a/project.clj
+++ b/project.clj
@@ -52,7 +52,8 @@
    {:repl-options {:port 8230}}
 
    :figwheel    ; Abitrary key, used in `lein with-profile +figwheel repl`.
-   {:dependencies [[com.cemerick/piggieback "0.2.1"]]  ; Needed by cljs-repl
+   {:dependencies [[com.cemerick/piggieback "0.2.1"]
+                   [org.clojure/tools.nrepl "0.2.10"]]  ; Needed by cljs-repl
     :repl-options {:nrepl-middleware
                    [cemerick.piggieback/wrap-cljs-repl]
 


### PR DESCRIPTION
Updates figwheel to support Eclipse for REPL and ignore the Eclipse Project file