### PR TITLE
Some fixes, especially a bug where all data was being blown away.

### DIFF
--- a/src/cljs/owlet_ui/components/activity_thumbnail.cljs
+++ b/src/cljs/owlet_ui/components/activity_thumbnail.cljs
@@ -20,7 +20,7 @@
        [:div.platform-wrap
         [:span "Platform: "]
         [:div.platform.btn
-          [set-as-showdown platform ]]]
+          [set-as-showdown platform]]]
        [:div.platform-wrap
         [:div.unplugged.btn
          "UNPLUGGED"]])

--- a/src/cljs/owlet_ui/components/back.cljs
+++ b/src/cljs/owlet_ui/components/back.cljs
@@ -2,6 +2,5 @@
   (:require [re-frame.core :as rf]))
 
 (defn back []
-  [:a {:href "#/branches"
-       :on-click #(rf/dispatch [:set-active-view :branches-view])}
+  [:a {:href "#/branches"}
     [:img.back {:src "/img/back-filled.png"}]])

--- a/src/cljs/owlet_ui/events.cljs
+++ b/src/cljs/owlet_ui/events.cljs
@@ -29,14 +29,6 @@
     (assoc-in cofx [:db :app :loading?] val)))
 
 
-(rf/reg-cofx
-  :close-sidebar!
-  (fn [cofx]
-    (let [db (:db cofx)]
-      (when-not (= (db :active-view) :welcome-view)
-        (assoc-in cofx [:db :app :open-sidebar] false)))))
-
-
 (rf/reg-event-db
   :set-active-document-title!
   (fn [db [_ val]]
@@ -109,13 +101,14 @@
 
 (rf/reg-event-db
   :set-active-view
-  [(rf/inject-cofx :close-sidebar!)]
   (fn [db [_ active-view]]
     (let [search (aget (js->clj (js/document.getElementsByClassName "form-control")) 0)]
       (when-not (nil? search)
         (set! (.-value search) "")
         (.blur search))
-      (assoc db :active-view active-view))))
+      (-> db
+        (assoc :active-view active-view)
+        (assoc-in [:app :open-sidebar] false)))))
 
 
 (reg-setter :show-bg-img-upload [:showing-bg-img-upload])

--- a/src/cljs/owlet_ui/views/not_found.cljs
+++ b/src/cljs/owlet_ui/views/not_found.cljs
@@ -8,4 +8,4 @@
         [:mark.white.box-shadow "Error 404 - Not Found"]]
    [:h3 [:mark.white "Hey there, this activity has moved to another URL."]]
    [:h3 [:mark.white "Chances are you'll find it inside a branch on the"]]
-   [:h3 [:mark.white [:a {:href "/branches"} "Branches page :)"]]]])
+   [:h3 [:mark.white [:a {:href "#/branches"} "Branches page :)"]]]])

--- a/src/cljs/owlet_ui/views/welcome.cljs
+++ b/src/cljs/owlet_ui/views/welcome.cljs
@@ -13,8 +13,7 @@
             [:div.welcome-text.text-shadow
               [:p "Explore some of the awesome things you can do with coding & multimedia, by yourself and with others. Enjoy!"]
               [:p "¡Bienvenidx a Owlet! Explora algunas de las cosas increíbles que puedes hacer con programación y con multimedios tú solx o en equipo. ¡Adelante!"]]
-            [:a {:href "#/branches"
-                 :on-click #(rf/dispatch [:set-active-view :branches-view])}
+            [:a {:href "#/branches"}
               [:button.btn.btn-branches "Go to Activities"]]]]
     [:div.login-landing
       [login-component]]


### PR DESCRIPTION
In working on login and authorization, I was frustrated by how the login data in `re-frame.db/app-db` often disappeared for no reason. I traced it to a bad `reg-cofx`, which was deleting **_all_** the contents of `app-db` whenever you visited a page other than `:welcome-view`! This was hard to isolate, since most _but not all_ of the data in `app-db` was reconstituted by the various event handlers.

I also fixed a couple other things I found.

- FIX: Data in `re-frame.db/app-db` being blown away by improper use of `re-frame.core/reg-cofx`.

- FIX: Event `[:set-active-view :branches-view]` needlessly being dispatched twice from each of `welcome.cljs` and `back.cljs`.

- FIX: Broken link in `not_found.cljs`.