### PR TITLE
refactor: waterfall-0

### DIFF
--- a/src/cljs/owlet_ui/config.cljs
+++ b/src/cljs/owlet_ui/config.cljs
@@ -13,7 +13,7 @@
 ;; Use a lein env var like the one above
 ;; to toggle this during development
 ;; http://localhost:3000
-(def server-url "http://localhost:3000")
+(def server-url "https://owlet-api.herokuapp.com")
 
 
 (def auth0-init

--- a/src/cljs/owlet_ui/config.cljs
+++ b/src/cljs/owlet_ui/config.cljs
@@ -13,11 +13,7 @@
 ;; Use a lein env var like the one above
 ;; to toggle this during development
 ;; http://localhost:3000
-(def server-url
-  "https://owlet-api.herokuapp.com")
-
-
-(defonce auth0-local-storage-key "owlet:user-token")
+(def server-url "http://localhost:3000")
 
 
 (def auth0-init


### PR DESCRIPTION
combines request for `/metadata` and `/activities` since now provided by single `/space` content