### PR TITLE
chore: update contentful endpoint, api moves to mmmanyfold API server

### DIFF
--- a/src/cljs/owlet_ui/config.cljs
+++ b/src/cljs/owlet_ui/config.cljs
@@ -9,11 +9,7 @@
 (def project-name "OWLET")
 
 
-;; TODO:
-;; Use a lein env var like the one above
-;; to toggle this during development
-;; http://localhost:3000
-(def server-url "https://owlet-api.herokuapp.com")
+(def server-url "https://mmmanyfold-api.herokuapp.com")
 
 
 (def auth0-init

--- a/src/cljs/owlet_ui/db.cljs
+++ b/src/cljs/owlet_ui/db.cljs
@@ -1,6 +1,5 @@
 (ns owlet-ui.db
-  (:require [owlet-ui.config :as config]
-            [owlet-ui.routes :refer [library-url]]))
+  (:require [owlet-ui.config :as config]))
 
 
 (def default-db

--- a/src/cljs/owlet_ui/events/contentful.cljs
+++ b/src/cljs/owlet_ui/events/contentful.cljs
@@ -11,7 +11,7 @@
 
 (defonce space-endpoint
          (str config/server-url
-              "/api/content/space?library-view=true&space-id="
+              "/owlet/api/content/space?library-view=true&space-id="
               config/owlet-activities-2-space-id))
 
 

--- a/src/cljs/owlet_ui/routes.cljs
+++ b/src/cljs/owlet_ui/routes.cljs
@@ -4,29 +4,7 @@
   (:require [secretary.core :as secretary]
             [goog.events :as events]
             [goog.history.EventType :as EventType]
-            [re-frame.core :as rf]
-            [ajax.core :refer [GET]]
-            [owlet-ui.config :as config]))
-
-
-(def library-url
-  "URL to obtain JSON containing the list of available activities.
-  "
-  (str config/server-url
-       "/api/content/entries?library-view=true&space-id="
-       config/owlet-activities-2-space-id))
-
-
-(defn get-then-dispatch
-  "Submits a GET request to the given URL and return immediately. The given
-  callback function, response->event, will be called with the response body
-  as argument, an EDN map.
-  "
-  [url response->event]
-  (GET url {:response-format :json
-            :keywords?       true
-            :handler         (comp rf/dispatch response->event)
-            :error-handler   #(prn %)}))
+            [re-frame.core :as rf]))
 
 
 (defn app-routes []


### PR DESCRIPTION
Since we now have a single consolidated endpoint (`/space`) for all contentful data. We are moving this to mmmanyfold's server to save on cost. In the future we can find a way for the front-end to make this request (via a lambda functions or a simple `GET`) and eliminate the need for the endpoint all together (maybe).

See: https://github.com/mmmanyfold/api/pull/8