### PR TITLE
FEAT-213: Implements new Contentful space and activity platform structure

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -573,6 +573,32 @@ img.back {
   }
 }
 
+.platform, .unplugged {
+  font-size: 1em;
+  padding: 5px 6px;
+}
+
+.platform {
+  color: white;
+  margin-bottom: 15px;
+  background-color: #00A79D;
+  &:hover {
+    background-color: #65D2C0;
+  }
+}
+
+.unplugged {
+  color: white;
+  background-color: #ec971f;
+  &:hover {
+    background-color: #f0ad4e;
+  }
+}
+
+.rc-popover-anchor-wrapper {
+  margin-bottom: 15px;
+}
+
 .activity-thumbnail-wrap {
   font-size: 0.9em;
   @media (max-width: 1187px) {
@@ -618,28 +644,11 @@ img.back {
     text-align: right;
   }
   .unplugged, .platform {
-    margin-top: 3px;
+    margin: 3px 0 0 0;
     padding: 5px 6px 4px 6px;
     font-size: 1.1em;
     p {
       margin: 0;
-    }
-  }
-  .platform {
-    background-color: #00A79D;
-    &:hover {
-      background-color: #65D2C0;
-    }
-    a {
-      text-decoration: none;
-      color: white;
-    }
-  }
-  .unplugged {
-    color: white;
-    background-color: #ec971f;
-    &:hover {
-      background-color: #f0ad4e;
     }
   }
   .tag {
@@ -694,7 +703,7 @@ img.back {
 
 .activity-info-wrap, .activity-inspiration-wrap, .activity-challenge-wrap {
   background-color: white;
-  padding: 10px 12px 2px 12px;
+  padding: 10px 12px 2px 15px;
 }
 
 .activity-challenge-wrap {

--- a/src/cljs/owlet_ui/components/activity/info.cljs
+++ b/src/cljs/owlet_ui/components/activity/info.cljs
@@ -19,9 +19,7 @@
         :showing? showing?
         :position :right-below
         :anchor [:button
-                 {:class         "btn btn-warning unplugged"
-                  :style         {:margin-bottom "10px"
-                                  :padding "5px 6px"};
+                 {:class         "btn unplugged"
                   :on-mouse-over (handler-fn (reset! showing? true))
                   :on-mouse-out  (handler-fn (reset! showing? false))}
                  "UNPLUGGED"]
@@ -29,7 +27,9 @@
                   :close-button? false
                   :title "What does this mean?"
                   :body "UNPLUGGED activities do not require a computer or device"]]
-       [set-as-showdown "<b>Platform</b><br>" platform])
+       [:div
+         [:b "Platform"] [:br]
+         [:button.btn.platform platform]])
      [set-as-showdown "<b>Summary</b><br>" summary]
      (when why
       [set-as-showdown "<b>Why?</b><br>" why])

--- a/src/cljs/owlet_ui/components/activity_thumbnail.cljs
+++ b/src/cljs/owlet_ui/components/activity_thumbnail.cljs
@@ -18,7 +18,7 @@
         [:mark.title title]]]
       (if platform
        [:div.platform-wrap
-        [:span "Platform: "]
+        [:b "Platform: "]
         [:div.platform.btn
           [set-as-showdown platform]]]
        [:div.platform-wrap

--- a/src/cljs/owlet_ui/components/search_bar.cljs
+++ b/src/cljs/owlet_ui/components/search_bar.cljs
@@ -56,7 +56,8 @@
               skills (rf/subscribe [:skills])
               activity-titles (rf/subscribe [:activity-titles])
               activity-platforms (rf/subscribe [:activity-platforms])
-              search-collections (concat @skills @branches @activity-titles @activity-platforms)
+              platform-names (map #(:name %) @activity-platforms)
+              search-collections (concat @skills @branches @activity-titles platform-names)
               result-formatter #(-> {:term %})
               suggestions-for-search
               (fn [s]

--- a/src/cljs/owlet_ui/config.cljs
+++ b/src/cljs/owlet_ui/config.cljs
@@ -9,11 +9,7 @@
 (def project-name "OWLET")
 
 
-;; TODO:
-;; Use a lein env var like the one above
-;; to toggle this during development
-;; http://localhost:3000
-(def server-url "http://localhost:3000")
+(def server-url "https://mmmanyfold-api.herokuapp.com")
 
 
 (def auth0-init

--- a/src/cljs/owlet_ui/config.cljs
+++ b/src/cljs/owlet_ui/config.cljs
@@ -13,7 +13,7 @@
 ;; Use a lein env var like the one above
 ;; to toggle this during development
 ;; http://localhost:3000
-(def server-url "https://owlet-api.herokuapp.com")
+(def server-url "http://localhost:3000")
 
 
 (def auth0-init
@@ -43,9 +43,6 @@
    :storageBucket "owlet-users.appspot.com"})
 
 
-(def library-space-id "c7i369745nqp")
-(def owlet-activities-2-space-id "ir2v150dybog")
-
+(def owlet-activities-3-space-id "0okl2i5aeorb")
 
 (def default-header-bg-image "img/default_background.png")
-

--- a/src/cljs/owlet_ui/db.cljs
+++ b/src/cljs/owlet_ui/db.cljs
@@ -1,6 +1,5 @@
 (ns owlet-ui.db
-  (:require [owlet-ui.config :as config]
-            [owlet-ui.routes :refer [library-url]]))
+  (:require [owlet-ui.config :as config]))
 
 
 (def default-db

--- a/src/cljs/owlet_ui/events/app.cljs
+++ b/src/cljs/owlet_ui/events/app.cljs
@@ -92,9 +92,6 @@
   :filter-activities-by-search-term
   (fn [db [_ term]]
 
-    (rf/dispatch [:set-active-view :search-results-view])
-    (rf/dispatch [:set-active-document-title! term])
-
     ;; by branch
     ;; ---------
 
@@ -116,6 +113,7 @@
           (if (seq filtered-set)
             (do
               (set-path (str "search/" (->kebab-case term)))
+              (rf/dispatch [:set-active-document-title! term])
               (assoc db :activities-by-branch-in-view (hash-map :activities filtered-set
                                                                 :display-name term)))
 

--- a/src/cljs/owlet_ui/events/app.cljs
+++ b/src/cljs/owlet_ui/events/app.cljs
@@ -5,7 +5,7 @@
             [owlet-ui.config :as config]
             [owlet-ui.rf-util :refer [reg-setter]]
             [owlet-ui.db :as db]
-            [owlet-ui.helpers :refer [keywordize-name parse-platform]]))
+            [owlet-ui.helpers :refer [keywordize-name]]))
 
 
 (defn note-pending
@@ -132,8 +132,7 @@
                 ;; by platform
                 ;; -----------
 
-                (let [filtered-set (filterv #(let [platform (-> (get-in % [:fields :platform])
-                                                                parse-platform)]
+                (let [filtered-set (filterv #(let [platform (get-in % [:fields :platform])]
                                                (when (= platform term) %)) activities)]
                   (if (seq filtered-set)
                     (do

--- a/src/cljs/owlet_ui/events/contentful.cljs
+++ b/src/cljs/owlet_ui/events/contentful.cljs
@@ -74,7 +74,7 @@
 
       (-> db
         (assoc
-          :activity-platforms (map #(get-in % [:fields :name]) platforms)
+          :activity-platforms (map #(:fields %) platforms)
           :activities
           (into []
             (for [activity activities]

--- a/src/cljs/owlet_ui/events/contentful.cljs
+++ b/src/cljs/owlet_ui/events/contentful.cljs
@@ -9,10 +9,11 @@
             [owlet-ui.helpers :refer
              [keywordize-name remove-nil]]))
 
+
 (defonce space-endpoint
          (str config/server-url
-              "/api/content/space?library-view=true&space-id="
-              config/owlet-activities-3-space-id))
+              "/owlet/api/content/space?library-view=true&space-id="
+              config/owlet-activities-2-space-id))
 
 
 (rf/reg-event-fx

--- a/src/cljs/owlet_ui/events/contentful.cljs
+++ b/src/cljs/owlet_ui/events/contentful.cljs
@@ -13,7 +13,7 @@
 (defonce space-endpoint
          (str config/server-url
               "/owlet/api/content/space?library-view=true&space-id="
-              config/owlet-activities-2-space-id))
+              config/owlet-activities-3-space-id))
 
 
 (rf/reg-event-fx

--- a/src/cljs/owlet_ui/helpers.cljs
+++ b/src/cljs/owlet_ui/helpers.cljs
@@ -20,15 +20,6 @@
 
 (def remove-nil (partial remove nil?))
 
-(defn parse-platform [term]
-  (if (not (nil? term))
-    (let [name (re-find #"\[+(.*)(\]+)" term)]
-      (if (seq name)
-        (second name)
-        term))
-    ""))
-
-
 (defn clean-search-term [term]
   (clj->str/trim
     (clj->str/replace term #"(\*)" "")))

--- a/src/cljs/owlet_ui/routes.cljs
+++ b/src/cljs/owlet_ui/routes.cljs
@@ -4,29 +4,7 @@
   (:require [secretary.core :as secretary]
             [goog.events :as events]
             [goog.history.EventType :as EventType]
-            [re-frame.core :as rf]
-            [ajax.core :refer [GET]]
-            [owlet-ui.config :as config]))
-
-
-(def library-url
-  "URL to obtain JSON containing the list of available activities.
-  "
-  (str config/server-url
-       "/api/content/entries?library-view=true&space-id="
-       config/owlet-activities-2-space-id))
-
-
-(defn get-then-dispatch
-  "Submits a GET request to the given URL and return immediately. The given
-  callback function, response->event, will be called with the response body
-  as argument, an EDN map.
-  "
-  [url response->event]
-  (GET url {:response-format :json
-            :keywords?       true
-            :handler         (comp rf/dispatch response->event)
-            :error-handler   #(prn %)}))
+            [re-frame.core :as rf]))
 
 
 (defn app-routes []

--- a/src/cljs/owlet_ui/routes.cljs
+++ b/src/cljs/owlet_ui/routes.cljs
@@ -29,6 +29,7 @@
             (rf/dispatch [:set-active-document-title! "Branches"]))
 
   (defroute "/search/:search" {:as params}
+            (rf/dispatch [:set-active-view :search-results-view])
             (rf/dispatch [:get-library-content-from-contentful params]))
 
   (defroute "/:branch" {:as params}


### PR DESCRIPTION
Switches to Contentful space `owlet-activities-3`, which has two types of entries: activity and platform. Activity entries have a reference field called `platformRef` which contains a reference to a platform entry (by sys id).

Closes https://github.com/codefordenver/owlet/issues/213