### PR TITLE
Remove extra cljsbuild task.

### DIFF
--- a/script/figwheel-repl.sh
+++ b/script/figwheel-repl.sh
@@ -47,10 +47,6 @@ for opt in $@; do
     esac
 done
 
-echo "$maybe_rlwrap lein do $maybe_clean cljsbuild once, with-profile $profile repl"
-$maybe_rlwrap lein do $maybe_clean cljsbuild once, with-profile $profile repl
-#
-# Here we explicitly invoked cljsbuild, so you'll see it in STDOUT running
-# twice. This seems to be needed to avoid an error, "REPL server launch timed
-# out."
+echo "$maybe_rlwrap lein do $maybe_clean with-profile $profile repl"
+$maybe_rlwrap lein do $maybe_clean with-profile $profile repl
 


### PR DESCRIPTION
It no longer seems to be necessary. Maybe latest Dirac has fixed the problem, where the build would issue a fatal error, "REPL server launch timed out", regardless of timeout setting.