### PR TITLE
Fix #193, "browser back navigation doesn't work".

### DIFF
--- a/src/cljs/owlet_ui/events/contentful.cljs
+++ b/src/cljs/owlet_ui/events/contentful.cljs
@@ -19,17 +19,12 @@
 (rf/reg-event-fx
   :get-library-content-from-contentful
   (fn [{db :db} [_ route-params]]
-    ;; short-circuit xhr request when we have activity data
-    (if-not (seq (:activities db))
-      {:db         (merge (assoc-in db [:app :loading?] true)
-                          (assoc-in db [:app :route-params] route-params))
-       :http-xhrio {:method          :get
-                    :uri             space-endpoint
-                    :response-format (ajax/json-response-format {:keywords? true})
-                    :on-success      [:get-library-content-from-contentful-successful]}}
-      ;; always assoc route-params for navigation
-      {:db         (merge (assoc-in db [:app :loading?] true)
-                          (assoc-in db [:app :route-params] route-params))})))
+    {:db         (merge (assoc-in db [:app :loading?] true)
+                        (assoc-in db [:app :route-params] route-params))
+     :http-xhrio {:method          :get
+                  :uri             space-endpoint
+                  :response-format (ajax/json-response-format {:keywords? true})
+                  :on-success      [:get-library-content-from-contentful-successful]}}))
 
 
 (rf/reg-event-db
@@ -149,12 +144,7 @@
                 skill    (rf/dispatch [:filter-activities-by-search-term skill])
                 activity (rf/dispatch [:set-activity-in-view activity all-activities])
                 branch   (let [activities-by-branch-in-view ((keyword branch) activities-by-branch)]
-                          (rf/dispatch [:set-activities-by-branch-in-view branch activities-by-branch-in-view])
-                          (assoc db :activity-branches branches
-                                    :skills skills
-                                    :activities-by-branch activities-by-branch
-                                    :activity-titles activity-titles))
-                :else db)))
+                          (rf/dispatch [:set-activities-by-branch-in-view branch activities-by-branch-in-view])))))
       (assoc db :activity-branches branches
                 :skills skills
                 :activities-by-branch activities-by-branch


### PR DESCRIPTION
I took a long look at this, and found that, as @eemshi suspected, it had to do with the "short-circuiting" in handler `:get-library-content-from-contentful`. The problem is that the dispatches done at the end of handler `:process-activity-metadata` are needed to make the db reflect the desired page. But one of the dispatches, to `:set-activities-by-branch-in-view`, depends upon the metadata in a response from Contentful, and all of the dispatches are together. Thus, updating the view when the back button is used depends upon hitting Contentful, which the short circuit inhibited. So the quick fix is to eliminate the short-circuiting.

The bug occurs whenever you visit more than one page in succession that each route to the same route handler. For example, visit `#/branch/game-design`, then `#/branch/digital-citizenship`, then `#/branch/computer-science`, then try the back button.

Namespace `contentful` _really_ needs to be refactored. This bug demonstrates what happens when there is inadequate separation of concerns. We shouldn't be complecting the update of the db with hitting Contentful. There is a lot of unnecessary complexity, like storing route parameters in the db. That should never be necessary, and it's error-prone, since you must dispatch to change the parameters. We're lucky that Contentful takes longer to respond than the dispatch takes to complete!

(I also removed a bit of unused code from the `:process-activity-metadata` handler.)