### PR TITLE
FEAT-235: Handles email confirmation & unsubscribe; completes email subscription feature

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -918,6 +918,17 @@ input[type="radio"]:checked + label{
   &:active {
     outline: 0;
   }
+
+}
+.email-unsubscribe{
+  padding: 10px;
+  margin: 30px 0;
+  background-color: @dark-gray;
+  width: 400px;
+  #email-button{
+    position: inherit;
+    margin-left: 90px;
+  }
 }
 .refresh {
   animation: refresh 1s 1;

--- a/src/cljs/owlet_ui/app.cljs
+++ b/src/cljs/owlet_ui/app.cljs
@@ -11,6 +11,7 @@
             [owlet-ui.views.activity :refer [activity-view]]
             [owlet-ui.views.branches :refer [branches-view]]
             [owlet-ui.views.subscribed :refer [subscribed-view]]
+            [owlet-ui.views.unsubscribe :refer [unsubscribe-view]]
             [owlet-ui.views.settings :refer [settings-view]]
             [owlet-ui.views.filtered-activities :refer [filtered-activities-view]]
             [owlet-ui.async :as async]
@@ -26,6 +27,7 @@
 (defmethod views :activity-view [] [activity-view])
 (defmethod views :branches-view [] [branches-view])
 (defmethod views :subscribed-view [] [subscribed-view])
+(defmethod views :unsubscribe-view [] [unsubscribe-view])
 (defmethod views :settings-view [] [settings-view])
 (defmethod views :default [] [:div])
 

--- a/src/cljs/owlet_ui/app.cljs
+++ b/src/cljs/owlet_ui/app.cljs
@@ -10,6 +10,7 @@
             [owlet-ui.views.not-found :refer [not-found-view]]
             [owlet-ui.views.activity :refer [activity-view]]
             [owlet-ui.views.branches :refer [branches-view]]
+            [owlet-ui.views.subscribed :refer [subscribed-view]]
             [owlet-ui.views.settings :refer [settings-view]]
             [owlet-ui.views.filtered-activities :refer [filtered-activities-view]]
             [owlet-ui.async :as async]
@@ -24,6 +25,7 @@
 (defmethod views :not-found-view [] [not-found-view])
 (defmethod views :activity-view [] [activity-view])
 (defmethod views :branches-view [] [branches-view])
+(defmethod views :subscribed-view [] [subscribed-view])
 (defmethod views :settings-view [] [settings-view])
 (defmethod views :default [] [:div])
 

--- a/src/cljs/owlet_ui/components/email_notification.cljs
+++ b/src/cljs/owlet_ui/components/email_notification.cljs
@@ -20,7 +20,7 @@
   (cond
 
     (or (= "Re-sent confirmation email." response)
-        (= "Added - awaiting confirmation." response)) (reset! res 2)
+        (= "Sent confirmation email." response)) (reset! res 2)
 
     (= "Already Subscribed." response) (reset! res 1)
 

--- a/src/cljs/owlet_ui/components/email_notification.cljs
+++ b/src/cljs/owlet_ui/components/email_notification.cljs
@@ -17,15 +17,19 @@
                           (js/setTimeout #(reset! msg true) 100)))
 
 (defn subscription-response [response]
-  (when (= "Subscribed." response)
-    (reset! res 2))
-  (when (= "Already Subscribed." response)
-    (reset! res 1)))
+  (cond
+
+    (or (= "Re-sent confirmation email." response)
+        (= "Added - awaiting confirmation." response)) (reset! res 2)
+
+    (= "Already Subscribed." response) (reset! res 1)
+
+    :else (reset! res 0)))
 
 (defn subscribe [email]
-  (PUT email-endpoint {:params {:email email}
-                       :format :json
-                       :handler subscription-response
+  (PUT email-endpoint {:params        {:email email}
+                       :format        :json
+                       :handler       subscription-response
                        :error-handler #(reset! res 0)}))
 
 (defn email-notification []
@@ -35,12 +39,12 @@
        [:p#email-text "Notify me when new activities are added"]
        (when @msg
          (cond
-           (= @res 2) [:p.refresh {:style {:color "green"}} "Success! You are now subscribed."]
+           (= @res 2) [:p.refresh {:style {:color "green"}} "Almost there! Check your email to confirm."]
            (= @res 1) [:p.refresh {:style {:color "yellow"}} "You are already subscribed."]
            (= @res 0) [:p.refresh {:style {:color "red"}} "Unsuccessful. Please try again."]))
-       [:input#email-input {:type "text"
+       [:input#email-input {:type        "text"
                             :placeholder "Email address"
-                            :on-change #(reset! email (-> % .-target .-value))
-                            :value @email}]
+                            :on-change   #(reset! email (-> % .-target .-value))
+                            :value       @email}]
        [:button#email-button {:on-click #(subscribe @email)}
-         "Subscribe"]])))
+        "Subscribe"]])))

--- a/src/cljs/owlet_ui/config.cljs
+++ b/src/cljs/owlet_ui/config.cljs
@@ -9,7 +9,7 @@
 (def project-name "OWLET")
 
 ;TODO: change this back to mmmanyfold
-(def server-url "http://localhost:3000")
+(def server-url "http://74d671d9.ngrok.io")
 
 
 (def auth0-init

--- a/src/cljs/owlet_ui/config.cljs
+++ b/src/cljs/owlet_ui/config.cljs
@@ -8,8 +8,8 @@
 
 (def project-name "OWLET")
 
-
-(def server-url "https://mmmanyfold-api.herokuapp.com")
+;TODO: change this back to mmmanyfold
+(def server-url "http://localhost:3000")
 
 
 (def auth0-init

--- a/src/cljs/owlet_ui/config.cljs
+++ b/src/cljs/owlet_ui/config.cljs
@@ -8,8 +8,8 @@
 
 (def project-name "OWLET")
 
-;TODO: change this back to mmmanyfold
-(def server-url "http://74d671d9.ngrok.io")
+
+(def server-url "https://mmmanyfold-api.herokuapp.com")
 
 
 (def auth0-init

--- a/src/cljs/owlet_ui/db.cljs
+++ b/src/cljs/owlet_ui/db.cljs
@@ -8,6 +8,7 @@
    :app                          {:loading?     nil
                                   :open-sidebar false
                                   :route-params {}
+                                  :route-opts nil
                                   :title        (str config/project-name " " "^OvO^")}
    :activities                   []
    :activity-branches            nil

--- a/src/cljs/owlet_ui/events/app.cljs
+++ b/src/cljs/owlet_ui/events/app.cljs
@@ -31,13 +31,15 @@
 
 (rf/reg-event-db
   :set-active-view
-  (fn [db [_ active-view]]
-    (let [search (aget (js->clj (js/document.getElementsByClassName "form-control")) 0)]
+  (fn [db [_ active-view opts]]
+    (let [email (:email opts)
+          search (aget (js->clj (js/document.getElementsByClassName "form-control")) 0)]
       (when-not (nil? search)
         (set! (.-value search) "")
         (.blur search))
       (-> db
           (assoc :active-view active-view)
+          (assoc-in [:app :route-opts] email)
           (assoc-in [:app :open-sidebar] false)))))
 
 

--- a/src/cljs/owlet_ui/routes.cljs
+++ b/src/cljs/owlet_ui/routes.cljs
@@ -22,6 +22,9 @@
   (defroute "/settings" []
             (rf/dispatch [:set-active-view :settings-view]))
 
+  (defroute "/subscribed/:email" {:as params}
+            (rf/dispatch [:set-active-view :subscribed-view params]))
+
   (defroute "/branches" []
             (rf/dispatch [:get-library-content-from-contentful])
             (rf/dispatch [:set-active-view :branches-view])

--- a/src/cljs/owlet_ui/routes.cljs
+++ b/src/cljs/owlet_ui/routes.cljs
@@ -25,6 +25,9 @@
   (defroute "/subscribed/:email" {:as params}
             (rf/dispatch [:set-active-view :subscribed-view params]))
 
+  (defroute "/unsubscribe" []
+            (rf/dispatch [:set-active-view :unsubscribe-view]))
+
   (defroute "/branches" []
             (rf/dispatch [:get-library-content-from-contentful])
             (rf/dispatch [:set-active-view :branches-view])

--- a/src/cljs/owlet_ui/subs.cljs
+++ b/src/cljs/owlet_ui/subs.cljs
@@ -61,3 +61,5 @@
 (reg-getter :activity-platforms [:activity-platforms])
 
 (reg-getter :route-params [:app :route-params])
+
+(reg-getter :subscriber-email [:app :route-opts])

--- a/src/cljs/owlet_ui/views/subscribed.cljs
+++ b/src/cljs/owlet_ui/views/subscribed.cljs
@@ -1,0 +1,12 @@
+(ns owlet-ui.views.subscribed
+  (:require [owlet-ui.components.back :refer [back]]
+            [re-frame.core :as rf]))
+
+(defn subscribed-view []
+  [:div.not-found
+   [:h2 [back]
+        [:mark.white.box-shadow "Thanks! You are now subscribed."]]
+   [:h3 [:mark.white "We will send an email notification to "
+                     [:span {:style {:color "#0275d8"}}
+                        @(rf/subscribe [:subscriber-email])]
+                     " whenever a new activity is posted."]]])

--- a/src/cljs/owlet_ui/views/unsubscribe.cljs
+++ b/src/cljs/owlet_ui/views/unsubscribe.cljs
@@ -1,0 +1,12 @@
+(ns owlet-ui.views.unsubscribe
+  (:require [owlet-ui.components.back :refer [back]]
+            [re-frame.core :as rf]))
+
+(defn unsubscribe-view []
+  [:div.not-found
+   [:h2 [back]
+        [:mark.white.box-shadow "Sorry to see you go"]]
+   [:h3 [:mark.white "Enter your email address to unsubscribe"]]])
+
+;TODO: add email address input form &
+     ; a PUT request to update user's :confirmed key to false]])

--- a/src/cljs/owlet_ui/views/unsubscribe.cljs
+++ b/src/cljs/owlet_ui/views/unsubscribe.cljs
@@ -1,12 +1,50 @@
 (ns owlet-ui.views.unsubscribe
   (:require [owlet-ui.components.back :refer [back]]
-            [re-frame.core :as rf]))
+            [re-frame.core :as rf]
+            [reagent.core :as reagent]
+            [ajax.core :as ajax :refer [GET POST PUT]]
+            [owlet-ui.config :as config]))
+
+(defonce email-endpoint
+         (str config/server-url
+              "/owlet/webhook/content/unsubscribe"))
+
+(def res (reagent/atom nil))
+
+(def msg (reagent/atom false))
+
+(add-watch res :watcher (fn [key atom old-state new-state]
+                          (reset! msg false)
+                          (js/setTimeout #(reset! msg true) 100)))
+
+(defn unsubscribe-response [response]
+  (cond
+
+    (or (= "Re-sent confirmation email." response)
+        (= "Added - awaiting confirmation." response)) (reset! res 2)
+
+    (= "Already Subscribed." response) (reset! res 1)
+
+    :else (reset! res 0)))
+
+(defn unsubscribe [email]
+  (PUT email-endpoint {:params        {:email email}
+                       :format        :json
+                       :handler       unsubscribe-response
+                       :error-handler #(reset! res 0)}))
 
 (defn unsubscribe-view []
-  [:div.not-found
-   [:h2 [back]
-        [:mark.white.box-shadow "Sorry to see you go"]]
-   [:h3 [:mark.white "Enter your email address to unsubscribe"]]])
+  (let [email (reagent/atom nil)]
+    [:div.not-found
+     [:h2 [back]
+          [:mark.white.box-shadow "Sorry to see you go"]]
+     [:h3 [:mark.white "Enter your email address to unsubscribe"]]
+     [:input#email-input {:type        "text"
+                          :placeholder "Email address"
+                          :on-change   #(reset! email (-> % .-target .-value))
+                          :value       @email}]
+     [:button#email-button {:on-click #(unsubscribe @email)}
+      "Unsubscribe"]]))
 
 ;TODO: add email address input form &
      ; a PUT request to update user's :confirmed key to false]])

--- a/src/cljs/owlet_ui/views/unsubscribe.cljs
+++ b/src/cljs/owlet_ui/views/unsubscribe.cljs
@@ -48,6 +48,3 @@
              (= @res 2) [:p.refresh {:style {:color "green"}} "Almost there!  Check your email to confirm."]
              (= @res 1) [:p.refresh {:style {:color "yellow"}} "You are not  subscribed."]
              (= @res 0) [:p.refresh {:style {:color "red"}} "Unsuccessful. Please try again."]))]])))
-
-;TODO: add email address input form &
-     ; a PUT request to update user's :confirmed key to false]])

--- a/src/cljs/owlet_ui/views/unsubscribe.cljs
+++ b/src/cljs/owlet_ui/views/unsubscribe.cljs
@@ -19,12 +19,8 @@
 
 (defn unsubscribe-response [response]
   (cond
-
-    (or (= "Re-sent confirmation email." response)
-        (= "Added - awaiting confirmation." response)) (reset! res 2)
-
-    (= "Already Subscribed." response) (reset! res 1)
-
+    (= "Sent confirmation email." response) (reset! res 2)
+    (= "Not Subscribed." response) (reset! res 1)
     :else (reset! res 0)))
 
 (defn unsubscribe [email]
@@ -39,12 +35,18 @@
      [:h2 [back]
           [:mark.white.box-shadow "Sorry to see you go"]]
      [:h3 [:mark.white "Enter your email address to unsubscribe"]]
-     [:input#email-input {:type        "text"
-                          :placeholder "Email address"
-                          :on-change   #(reset! email (-> % .-target .-value))
-                          :value       @email}]
-     [:button#email-button {:on-click #(unsubscribe @email)}
-      "Unsubscribe"]]))
+     [:div.email-unsubscribe
+       [:input#email-input {:type        "text"
+                            :placeholder "Email address"
+                            :on-change   #(reset! email (-> % .-target .-value))
+                            :value       @email}]
+       [:button#email-button {:on-click #(unsubscribe @email)}
+        "Unsubscribe"]]
+       (when @msg
+         (cond
+           (= @res 2) [:p.refresh {:style {:color "green"}} "Almost there!  Check your email to confirm."]
+           (= @res 1) [:p.refresh {:style {:color "yellow"}} "You are not  subscribed."]
+           (= @res 0) [:p.refresh {:style {:color "red"}} "Unsuccessful. Please try again."]))]))
 
 ;TODO: add email address input form &
      ; a PUT request to update user's :confirmed key to false]])

--- a/src/cljs/owlet_ui/views/unsubscribe.cljs
+++ b/src/cljs/owlet_ui/views/unsubscribe.cljs
@@ -31,22 +31,23 @@
 
 (defn unsubscribe-view []
   (let [email (reagent/atom nil)]
-    [:div.not-found
-     [:h2 [back]
-          [:mark.white.box-shadow "Sorry to see you go"]]
-     [:h3 [:mark.white "Enter your email address to unsubscribe"]]
-     [:div.email-unsubscribe
-       [:input#email-input {:type        "text"
-                            :placeholder "Email address"
-                            :on-change   #(reset! email (-> % .-target .-value))
-                            :value       @email}]
-       [:button#email-button {:on-click #(unsubscribe @email)}
-        "Unsubscribe"]]
-       (when @msg
-         (cond
-           (= @res 2) [:p.refresh {:style {:color "green"}} "Almost there!  Check your email to confirm."]
-           (= @res 1) [:p.refresh {:style {:color "yellow"}} "You are not  subscribed."]
-           (= @res 0) [:p.refresh {:style {:color "red"}} "Unsuccessful. Please try again."]))]))
+    (fn []
+      [:div.not-found
+       [:h2 [back]
+            [:mark.white.box-shadow "Sorry to see you go"]]
+       [:h3 [:mark.white "Enter your email address to unsubscribe"]]
+       [:div.email-unsubscribe
+         [:input#email-input {:type        "text"
+                              :placeholder "Email address"
+                              :on-change   #(reset! email (-> % .-target .-value))
+                              :value       @email}]
+         [:button#email-button {:on-click #(unsubscribe @email)}
+          "Unsubscribe"]
+         (when @msg
+           (cond
+             (= @res 2) [:p.refresh {:style {:color "green"}} "Almost there!  Check your email to confirm."]
+             (= @res 1) [:p.refresh {:style {:color "yellow"}} "You are not  subscribed."]
+             (= @res 0) [:p.refresh {:style {:color "red"}} "Unsuccessful. Please try again."]))]])))
 
 ;TODO: add email address input form &
      ; a PUT request to update user's :confirmed key to false]])


### PR DESCRIPTION
closes https://github.com/codefordenver/owlet/issues/235

Must merge with https://github.com/mmmanyfold/api/pull/12

TODO:
- [x] add email form & PUT request to unsubscribe-view
- [x] test response codes in email-notification component
- [x] use subscriber id instead of email in confirmation url
- [x] create view for unsubscription redirect at /#/unsubscribed