### PR TITLE
Refactors contentful.cljs to reduce complexity & side-effects

### DIFF
--- a/src/cljs/owlet_ui/events/app.cljs
+++ b/src/cljs/owlet_ui/events/app.cljs
@@ -114,7 +114,7 @@
               (set-path (str "skill/" (->kebab-case term)))
               (rf/dispatch [:set-active-document-title! term])
               (assoc db :activities-by-filter (hash-map :activities filtered-set
-                                                                :display-name term)))
+                                                        :display-name term)))
 
             ;; by activity name (title)
             ;; ------------------------
@@ -137,6 +137,6 @@
                                         (:activity-platforms db))]
                       (set-path (str "platform/" term))
                       (assoc db :activities-by-filter (hash-map :activities filtered-set
-                                                                        :display-name platform-name
-                                                                        :description description)))
+                                                                :display-name platform-name
+                                                                :description description)))
                     (assoc db :activities-by-filter "error")))))))))))

--- a/src/cljs/owlet_ui/events/contentful.cljs
+++ b/src/cljs/owlet_ui/events/contentful.cljs
@@ -30,20 +30,9 @@
 (rf/reg-event-db
   :get-library-content-from-contentful-successful
   (fn [db [_ {activities :activities metadata :metadata platforms :platforms}]]
-
-    (rf/dispatch [:process-activity-metadata metadata])
-    (-> db
-      (assoc
-        :activity-platforms (map #(:fields %) platforms)
-        :activities activities))))
-
-(rf/reg-event-db
-  :process-activity-metadata
-  (fn [db [_ metadata]]
     (let [branches (:branches metadata)
           skills (:skills metadata)
-          all-activities (:activities db)
-          activity-titles (remove-nil (map #(get-in % [:fields :title]) all-activities))
+          activity-titles (remove-nil (map #(get-in % [:fields :title]) activities))
           branches-template (->> (mapv (fn [branch]
                                          (hash-map (keywordize-name branch)
                                            {:activities   []
@@ -58,7 +47,7 @@
                                                     matches (filterv (fn [activity]
                                                                        (some #(= display-name %)
                                                                          (get-in activity [:fields :branch])))
-                                                              all-activities)
+                                                              activities)
                                                     preview-urls (mapv #(get-in % [:fields :preview :sys :url]) matches)]
                                                 (if (seq matches)
                                                   (hash-map branch-key
@@ -69,14 +58,11 @@
                                                   branch))))
                                       branches-template)
                                  (into {}))]
-      (when-let [route-params (get-in db [:app :route-params])]
-        (let [{:keys [activity branch skill platform]} route-params]
-          (cond platform (rf/dispatch [:filter-activities-by-search-term platform])
-                skill    (rf/dispatch [:filter-activities-by-search-term skill])
-                activity (rf/dispatch [:set-activity-in-view activity all-activities])
-                branch   (let [activities-by-branch-in-view ((keyword branch) activities-by-branch)]
-                          (rf/dispatch [:set-activities-by-branch-in-view branch activities-by-branch-in-view])))))
-      (assoc db :activity-branches branches
-                :skills skills
-                :activities-by-branch activities-by-branch
-                :activity-titles activity-titles))))
+      (-> db
+        (assoc
+          :activity-platforms (map #(:fields %) platforms)
+          :activities activities
+          :activity-branches branches
+          :skills skills
+          :activities-by-branch activities-by-branch
+          :activity-titles activity-titles)))))

--- a/src/cljs/owlet_ui/routes.cljs
+++ b/src/cljs/owlet_ui/routes.cljs
@@ -29,25 +29,29 @@
             (rf/dispatch [:set-active-view :unsubscribe-view]))
 
   (defroute "/branches" []
-            (rf/dispatch [:get-library-content-from-contentful])
+            (rf/dispatch [:get-library-content-from-contentful params])
             (rf/dispatch [:set-active-view :branches-view])
             (rf/dispatch [:set-active-document-title! "Branches"]))
 
   (defroute "/skill/:skill" {:as params}
+            (rf/dispatch [:get-library-content-from-contentful params])
             (rf/dispatch [:set-active-view :filtered-activities-view])
-            (rf/dispatch [:get-library-content-from-contentful params]))
+            (rf/dispatch [:filter-activities-by-search-term (:skill params)]))
 
   (defroute "/platform/:platform" {:as params}
+            (rf/dispatch [:get-library-content-from-contentful params])
             (rf/dispatch [:set-active-view :filtered-activities-view])
-            (rf/dispatch [:get-library-content-from-contentful params]))
+            (rf/dispatch [:filter-activities-by-search-term (:platform params)]))
 
   (defroute "/branch/:branch" {:as params}
             (rf/dispatch [:get-library-content-from-contentful params])
+            (rf/dispatch [:filter-activities-by-search-term (:branch params)])
             (rf/dispatch [:set-active-view :filtered-activities-view])
             (rf/dispatch [:set-active-document-title! (:branch params)]))
 
   (defroute "/activity/#!:activity" {:as params}
             (rf/dispatch [:get-library-content-from-contentful params])
+            (rf/dispatch [:filter-activities-by-search-term (:activity params)])
             (rf/dispatch [:set-active-view :activity-view]))
 
   (defroute "*" []


### PR DESCRIPTION
TODO:
- [x] get rid of `:process-activity-metadata` dispatch in `:get-library-content-from-contentful`
- [ ] stop storing route-params
- [ ] resolve timing of `:get-library-content-from-contentful` and `:filter-activities-by-search-term` (see `routes.cljs`)
- [ ] handle `set-path` in `:filter-activities-by-search-term` as a coeffect
- [ ] handle `:set-active-document-title!` as an effect?
- [ ] consolidate `:set-activities-by-branch-in-view` with `:filter-activities-by-search-term`
- [ ] update error message for search not found