### PR TITLE
Refactors handlers to reduce complexity & side-effects

### DIFF
--- a/src/cljs/owlet_ui/app.cljs
+++ b/src/cljs/owlet_ui/app.cljs
@@ -22,7 +22,7 @@
 (defmulti views identity)
 (defmethod views :welcome-view [] [welcome-view])
 (defmethod views :filtered-activities-view []
-  [filtered-activities-view (first (keys @(rf/subscribe [:route-params])))])
+  [filtered-activities-view])
 (defmethod views :not-found-view [] [not-found-view])
 (defmethod views :activity-view [] [activity-view])
 (defmethod views :branches-view [] [branches-view])

--- a/src/cljs/owlet_ui/components/activity/embed.cljs
+++ b/src/cljs/owlet_ui/components/activity/embed.cljs
@@ -21,5 +21,5 @@
           "SKILLS: "]
         (for [skill skills]
          ^{:key (gensym "skill-")}
-          [:div.tag {:on-click #(rf/dispatch [:filter-activities-by-search-term skill])}
+          [:div.tag {:on-click #(rf/dispatch [:show-skill skill])}
             [:span skill]])])]))

--- a/src/cljs/owlet_ui/components/activity/info.cljs
+++ b/src/cljs/owlet_ui/components/activity/info.cljs
@@ -23,7 +23,7 @@
         :showing? showing?
         :position :below-left
         :anchor [:button.platform.btn
-                 {:on-click #(rf/dispatch [:filter-activities-by-search-term platform-search-name])
+                 {:on-click #(rf/dispatch [:show-platform platform-search-name])
                   :style {:background-color platform-color}
                   :on-mouse-over (handler-fn (reset! showing? true))
                   :on-mouse-out  (handler-fn (reset! showing? false))}

--- a/src/cljs/owlet_ui/components/activity_thumbnail.cljs
+++ b/src/cljs/owlet_ui/components/activity_thumbnail.cljs
@@ -16,8 +16,7 @@
         showing? (reagent/atom false)]
     [:div.col-xs-12.col-md-6.col-lg-4
      [:div.activity-thumbnail-wrap.box-shadow
-      [:a {:href     (str "#/activity/#!" entry-id)
-           :on-click #(rf/dispatch [:set-activity-in-view entry-id])}
+      [:a {:href (str "#/activity/#!" entry-id)}
        [:div.activity-thumbnail {:style {:background-image (str "url('" image "')")}}
         [:mark.title title]]]
       [:div.platform-wrap
@@ -26,7 +25,7 @@
          :showing? showing?
          :position :below-left
          :anchor [:div.platform.btn
-                  {:on-click #(rf/dispatch [:filter-activities-by-search-term platform-search-name])
+                  {:on-click #(rf/dispatch [:show-platform platform-search-name])
                    :style {:background-color platform-color}
                    :on-mouse-over (when (not= route-param :platform)
                                     (handler-fn (reset! showing? true)))
@@ -40,5 +39,5 @@
       (when skills
         (for [skill skills]
           ^{:key (gensym "skill-")}
-          [:div.tag {:on-click #(rf/dispatch [:filter-activities-by-search-term skill])}
+          [:div.tag {:on-click #(rf/dispatch [:show-skill skill])}
             [:span skill]]))]]))

--- a/src/cljs/owlet_ui/components/branch.cljs
+++ b/src/cljs/owlet_ui/components/branch.cljs
@@ -40,10 +40,7 @@
                     :background-image (str "linear-gradient(to right, "
                                            color
                                            " 25%, rgba(0,0,0,0) 75%")}}
-           [:a.branch {:on-click #(rf/dispatch-sync
-                                   [:set-activities-by-branch-in-view
-                                    (->kebab-case branch-name)])
-                       :href     (str "#/branch/" (->kebab-case branch-name))}
+           [:a.branch {:href (str "#/branch/" (->kebab-case branch-name))}
             [:h2 [:mark name-line1]
              (when (<= 1 (count name-line2))
                [:span

--- a/src/cljs/owlet_ui/events/app.cljs
+++ b/src/cljs/owlet_ui/events/app.cljs
@@ -114,7 +114,7 @@
               (set-path (str "skill/" (->kebab-case term)))
               (rf/dispatch [:set-active-document-title! term])
               (assoc db :activities-by-filter (hash-map :activities filtered-set
-                                                                :display-name term)))
+                                                        :display-name term)))
 
             ;; by activity name (title)
             ;; ------------------------
@@ -137,6 +137,6 @@
                                         (:activity-platforms db))]
                       (set-path (str "platform/" term))
                       (assoc db :activities-by-filter (hash-map :activities filtered-set
-                                                                        :display-name platform-name
-                                                                        :description description)))
+                                                                :display-name platform-name
+                                                                :description description)))
                     (assoc db :activities-by-filter "error")))))))))))

--- a/src/cljs/owlet_ui/events/app.cljs
+++ b/src/cljs/owlet_ui/events/app.cljs
@@ -71,72 +71,8 @@
 
 
 (rf/reg-event-db
-  :set-activities-by-branch-in-view
-  (fn [db [_ branch-name activities-by-branch]]
-    (if-let [activities-by-branch ((keyword branch-name) (or (:activities-by-branch db) activities-by-branch))]
-      (assoc db :activities-by-filter activities-by-branch)
-      (assoc db :activities-by-filter "error"))))
-
-
-(rf/reg-event-db
   :set-activity-in-view
   (fn [db [_ activity-id all-activities]]
-    (if-let [activity-match (some #(when (= (get-in % [:sys :id]) activity-id) %)
+    (when-let [activity-match (some #(when (= (get-in % [:sys :id]) activity-id) %)
                                   (or (:activities db) all-activities))]
-      (assoc db :activity-in-view activity-match)
-      (assoc db :activity-in-view "error"))))
-
-
-(rf/reg-event-db
-  :filter-activities-by-search-term
-  (fn [db [_ term]]
-
-    ;; by branch
-    ;; ---------
-
-    (let [search-term (keywordize-name term)
-          activities (:activities db)
-          set-path (fn [path]
-                    (set! (.-location js/window) (str "/#/" path)))]
-
-
-      (if-let [filtered-set (search-term (:activities-by-branch db))]
-        (do
-          (set-path (str "branch/" (->kebab-case term)))
-          (assoc db :activities-by-filter filtered-set))
-
-        ;; by skill
-        ;; --------
-
-        (let [filtered-set (filter #(when (contains? (:skill-set %) search-term) %) activities)]
-          (if (seq filtered-set)
-            (do
-              (set-path (str "skill/" (->kebab-case term)))
-              (rf/dispatch [:set-active-document-title! term])
-              (assoc db :activities-by-filter (hash-map :activities filtered-set
-                                                        :display-name term)))
-
-            ;; by activity name (title)
-            ;; ------------------------
-
-            (let [filtered-set (filter #(when (= (get-in % [:fields :title]) term) %) activities)]
-              (if (seq filtered-set)
-                (let [activity (first filtered-set)
-                      activity-id (get-in activity [:sys :id])]
-                  (set-path (str "activity/#!" activity-id))
-                  (assoc db :activity-in-view activity))
-
-                ;; by platform
-                ;; -----------
-
-                (let [filtered-set (filter #(let [platform (get-in % [:fields :platform :search-name])]
-                                               (when (= platform term) %)) activities)
-                      platform-name (get-in (first filtered-set) [:fields :platform :name])]
-                  (if (seq filtered-set)
-                    (let [description (some #(when (= platform-name (:name %)) (:description %))
-                                        (:activity-platforms db))]
-                      (set-path (str "platform/" term))
-                      (assoc db :activities-by-filter (hash-map :activities filtered-set
-                                                                :display-name platform-name
-                                                                :description description)))
-                    (assoc db :activities-by-filter "error")))))))))))
+      (assoc db :activity-in-view activity-match))))

--- a/src/cljs/owlet_ui/events/contentful.cljs
+++ b/src/cljs/owlet_ui/events/contentful.cljs
@@ -27,7 +27,6 @@
                       :on-success      [:get-content-from-contentful-success route-args]}}
         {:dispatch [route-dispatch route-param]}))))
 
-
 (rf/reg-event-fx
   :get-content-from-contentful-success
   (fn [{db :db} [_ route-args {activities :activities metadata :metadata platforms :platforms}]]
@@ -70,24 +69,41 @@
             :activity-titles activity-titles)
        :dispatch [route-dispatch route-param]})))
 
-;TODO: add :show-skill, :show-activity
+
+; route dispatches
 
 (rf/reg-event-fx
   :show-branches
   (fn [_ _]
-    {:dispatch [:set-active-view :branches-view]}))
-
-(rf/reg-event-fx
-  :show-platform
-  (fn [_ route-param]
-    {:dispatch-n (list [:set-active-view :filtered-activities-view "platform"]
-                       [:filter-activities-by-search-term (second route-param)])}))
+    {:dispatch-n (list [:set-active-view :branches-view]
+                       [:set-active-document-title! "Branches"])}))
 
 (rf/reg-event-fx
   :show-branch
-  (fn [_ route-param]
+  (fn [_ [_ route-param]]
     {:dispatch-n (list [:set-active-view :filtered-activities-view "branch"]
-                       [:filter-activities-by-search-term (second route-param)])}))
+                       [:filter-activities-by-search-term route-param]
+                       [:set-active-document-title! route-param])}))
+
+(rf/reg-event-fx
+  :show-platform
+  (fn [_ [_ route-param]]
+    {:dispatch-n (list [:set-active-view :filtered-activities-view "platform"]
+                       [:filter-activities-by-search-term route-param]
+                       [:set-active-document-title! route-param])}))
+
+(rf/reg-event-fx
+  :show-skill
+  (fn [_ [_ route-param]]
+    {:dispatch-n (list [:set-active-view :filtered-activities-view "branch"]
+                       [:filter-activities-by-search-term route-param]
+                       [:set-active-document-title! route-param])}))
+
+(rf/reg-event-fx
+  :show-activity
+  (fn [_ [_ route-param]]
+    {:dispatch-n (list [:set-active-view :activity-view]
+                       [:set-activity-in-view route-param])}))
 
 
 (rf/reg-event-db
@@ -113,7 +129,7 @@
           (if (seq filtered-set)
             (do
               (set-path (str "skill/" (->kebab-case term)))
-              (rf/dispatch [:set-active-document-title! term])
+              ; (rf/dispatch [:set-active-document-title! term])
               (assoc db :activities-by-filter (hash-map :activities filtered-set
                                                         :display-name term)))
 

--- a/src/cljs/owlet_ui/events/contentful.cljs
+++ b/src/cljs/owlet_ui/events/contentful.cljs
@@ -30,20 +30,9 @@
 (rf/reg-event-db
   :get-library-content-from-contentful-successful
   (fn [db [_ {activities :activities metadata :metadata platforms :platforms}]]
-
-    (rf/dispatch [:process-activity-metadata metadata])
-    (-> db
-      (assoc
-        :activity-platforms (map #(:fields %) platforms)
-        :activities activities))))
-
-(rf/reg-event-db
-  :process-activity-metadata
-  (fn [db [_ metadata]]
     (let [branches (:branches metadata)
           skills (:skills metadata)
-          all-activities (:activities db)
-          activity-titles (remove-nil (map #(get-in % [:fields :title]) all-activities))
+          activity-titles (remove-nil (map #(get-in % [:fields :title]) activities))
           branches-template (->> (mapv (fn [branch]
                                          (hash-map (keywordize-name branch)
                                            {:activities   []
@@ -58,7 +47,7 @@
                                                     matches (filterv (fn [activity]
                                                                        (some #(= display-name %)
                                                                          (get-in activity [:fields :branch])))
-                                                              all-activities)
+                                                              activities)
                                                     preview-urls (mapv #(get-in % [:fields :preview :sys :url]) matches)]
                                                 (if (seq matches)
                                                   (hash-map branch-key
@@ -69,14 +58,11 @@
                                                   branch))))
                                       branches-template)
                                  (into {}))]
-      (when-let [route-params (get-in db [:app :route-params])]
-        (let [{:keys [activity branch skill platform]} route-params]
-          (cond platform (rf/dispatch [:filter-activities-by-search-term platform])
-                skill    (rf/dispatch [:filter-activities-by-search-term skill])
-                activity (rf/dispatch [:set-activity-in-view activity all-activities])
-                branch   (let [activities-by-branch-in-view ((keyword branch) activities-by-branch)]
-                          (rf/dispatch [:set-activities-by-branch-in-view branch activities-by-branch-in-view])))))
-      (assoc db :activity-branches branches
-                :skills skills
-                :activities-by-branch activities-by-branch
-                :activity-titles activity-titles))))
+      (-> db
+        (assoc
+          :activity-platforms (map #(:fields %) platforms)
+          :activities activities
+          :activity-branches branches
+          :skills skills
+          :activities-by-branch activities-by-branch
+          :activity-titles activity-titles)))))

--- a/src/cljs/owlet_ui/events/contentful.cljs
+++ b/src/cljs/owlet_ui/events/contentful.cljs
@@ -129,7 +129,6 @@
           (if (seq filtered-set)
             (do
               (set-path (str "skill/" (->kebab-case term)))
-              ; (rf/dispatch [:set-active-document-title! term])
               (assoc db :activities-by-filter (hash-map :activities filtered-set
                                                         :display-name term)))
 

--- a/src/cljs/owlet_ui/events/contentful.cljs
+++ b/src/cljs/owlet_ui/events/contentful.cljs
@@ -17,20 +17,23 @@
 
 
 (rf/reg-event-fx
-  :get-library-content-from-contentful
-  (fn [{db :db} [_ route-params]]
-    {:db         (merge (assoc-in db [:app :loading?] true)
-                        (assoc-in db [:app :route-params] route-params))
-     :http-xhrio {:method          :get
-                  :uri             space-endpoint
-                  :response-format (ajax/json-response-format {:keywords? true})
-                  :on-success      [:get-library-content-from-contentful-successful]}}))
+  :get-content-from-contentful
+  (fn [{db :db} route-args]
+    (let [[_ route-dispatch route-param] route-args]
+      (if-not (seq (:activities db))
+        {:http-xhrio {:method          :get
+                      :uri             space-endpoint
+                      :response-format (ajax/json-response-format {:keywords? true})
+                      :on-success      [:get-content-from-contentful-success route-args]}}
+        {:dispatch [route-dispatch route-param]}))))
 
 
-(rf/reg-event-db
-  :get-library-content-from-contentful-successful
-  (fn [db [_ {activities :activities metadata :metadata platforms :platforms}]]
-    (let [branches (:branches metadata)
+(rf/reg-event-fx
+  :get-content-from-contentful-success
+  (fn [{db :db} [_ route-args {activities :activities metadata :metadata platforms :platforms}]]
+    (let [route-dispatch (second route-args)
+          route-param (get route-args 2)
+          branches (:branches metadata)
           skills (:skills metadata)
           activity-titles (remove-nil (map #(get-in % [:fields :title]) activities))
           branches-template (->> (mapv (fn [branch]
@@ -58,11 +61,89 @@
                                                   branch))))
                                       branches-template)
                                  (into {}))]
-      (-> db
-        (assoc
-          :activity-platforms (map #(:fields %) platforms)
-          :activities activities
-          :activity-branches branches
-          :skills skills
-          :activities-by-branch activities-by-branch
-          :activity-titles activity-titles)))))
+      {:db (assoc db
+            :activity-platforms (map #(:fields %) platforms)
+            :activities activities
+            :activity-branches branches
+            :skills skills
+            :activities-by-branch activities-by-branch
+            :activity-titles activity-titles)
+       :dispatch [route-dispatch route-param]})))
+
+;TODO: add :show-skill, :show-activity
+
+(rf/reg-event-fx
+  :show-branches
+  (fn [_ _]
+    {:dispatch [:set-active-view :branches-view]}))
+
+(rf/reg-event-fx
+  :show-platform
+  (fn [_ route-param]
+    {:dispatch-n (list [:set-active-view :filtered-activities-view "platform"]
+                       [:filter-activities-by-search-term (second route-param)])}))
+
+(rf/reg-event-fx
+  :show-branch
+  (fn [_ route-param]
+    {:dispatch-n (list [:set-active-view :filtered-activities-view "branch"]
+                       [:filter-activities-by-search-term (second route-param)])}))
+
+
+(rf/reg-event-db
+  :filter-activities-by-search-term
+  (fn [db [_ term]]
+    (let [search-term (keywordize-name term)
+          activities (:activities db)
+          set-path (fn [path]
+                    (set! (.-location js/window) (str "/#/" path)))]
+
+      ;; by branch
+      ;; ---------
+
+      (if-let [filtered-set (search-term (:activities-by-branch db))]
+        (do
+          (set-path (str "branch/" (->kebab-case term)))
+          (assoc db :activities-by-filter filtered-set))
+
+        ;; by skill
+        ;; --------
+
+        (let [filtered-set (filter #(when (contains? (:skill-set %) term) %) activities)]
+          (if (seq filtered-set)
+            (do
+              (set-path (str "skill/" (->kebab-case term)))
+              (rf/dispatch [:set-active-document-title! term])
+              (assoc db :activities-by-filter (hash-map :activities filtered-set
+                                                        :display-name term)))
+
+            ;; by activity name (title)
+            ;; ------------------------
+
+            (let [filtered-set (filter #(when (= (get-in % [:fields :title]) term) %) activities)]
+              (if (seq filtered-set)
+                (let [activity (first filtered-set)
+                      activity-id (get-in activity [:sys :id])]
+                  (set-path (str "activity/#!" activity-id))
+                  (assoc db :activity-in-view activity))
+
+                ;; by activity id
+                ;; ------------------------
+
+                (if-let [activity (some #(when (= (get-in % [:sys :id]) term) %) activities)]
+                  (assoc db :activity-in-view activity)
+
+                  ;; by platform
+                  ;; -----------
+
+                  (let [filtered-set (filter #(let [platform (get-in % [:fields :platform :search-name])]
+                                                 (when (= platform term) %)) activities)
+                        platform-name (get-in (first filtered-set) [:fields :platform :name])]
+                    (if (seq filtered-set)
+                      (let [description (some #(when (= platform-name (:name %)) (:description %))
+                                          (:activity-platforms db))]
+                        (set-path (str "platform/" term))
+                        (assoc db :activities-by-filter (hash-map :activities filtered-set
+                                                                  :display-name platform-name
+                                                                  :description description)))
+                      (assoc db :activities-by-filter "error"))))))))))))

--- a/src/cljs/owlet_ui/routes.cljs
+++ b/src/cljs/owlet_ui/routes.cljs
@@ -29,25 +29,29 @@
             (rf/dispatch [:set-active-view :unsubscribe-view]))
 
   (defroute "/branches" []
-            (rf/dispatch [:get-library-content-from-contentful])
+            (rf/dispatch [:get-library-content-from-contentful params])
             (rf/dispatch [:set-active-view :branches-view])
             (rf/dispatch [:set-active-document-title! "Branches"]))
 
   (defroute "/skill/:skill" {:as params}
+            (rf/dispatch [:get-library-content-from-contentful params])
             (rf/dispatch [:set-active-view :filtered-activities-view])
-            (rf/dispatch [:get-library-content-from-contentful params]))
+            (rf/dispatch [:filter-activities-by-search-term (:skill params)]))
 
   (defroute "/platform/:platform" {:as params}
+            (rf/dispatch [:get-library-content-from-contentful params])
             (rf/dispatch [:set-active-view :filtered-activities-view])
-            (rf/dispatch [:get-library-content-from-contentful params]))
+            (rf/dispatch [:filter-activities-by-search-term (:platform params)]))
 
   (defroute "/branch/:branch" {:as params}
             (rf/dispatch [:get-library-content-from-contentful params])
+            (rf/dispatch [:filter-activities-by-search-term (:branch params)])
             (rf/dispatch [:set-active-view :filtered-activities-view])
             (rf/dispatch [:set-active-document-title! (:branch params)]))
 
   (defroute "/activity/#!:activity" {:as params}
             (rf/dispatch [:get-library-content-from-contentful params])
+            (rf/dispatch [:filter-activities-by-search-term (:activity params)])
             (rf/dispatch [:set-active-view :activity-view]))
 
   (defroute "*" []

--- a/src/cljs/owlet_ui/routes.cljs
+++ b/src/cljs/owlet_ui/routes.cljs
@@ -28,31 +28,24 @@
   (defroute "/unsubscribe" []
             (rf/dispatch [:set-active-view :unsubscribe-view]))
 
+  ;TODO: remove :set-active-document-title!
+
   (defroute "/branches" []
-            (rf/dispatch [:get-library-content-from-contentful params])
-            (rf/dispatch [:set-active-view :branches-view])
+            (rf/dispatch [:get-content-from-contentful :show-branches])
             (rf/dispatch [:set-active-document-title! "Branches"]))
 
   (defroute "/skill/:skill" {:as params}
-            (rf/dispatch [:get-library-content-from-contentful params])
-            (rf/dispatch [:set-active-view :filtered-activities-view])
-            (rf/dispatch [:filter-activities-by-search-term (:skill params)]))
+            (rf/dispatch [:get-content-from-contentful :show-skill (:skill params)]))
 
   (defroute "/platform/:platform" {:as params}
-            (rf/dispatch [:get-library-content-from-contentful params])
-            (rf/dispatch [:set-active-view :filtered-activities-view])
-            (rf/dispatch [:filter-activities-by-search-term (:platform params)]))
+            (rf/dispatch [:get-content-from-contentful :show-platform (:platform params)]))
 
   (defroute "/branch/:branch" {:as params}
-            (rf/dispatch [:get-library-content-from-contentful params])
-            (rf/dispatch [:filter-activities-by-search-term (:branch params)])
-            (rf/dispatch [:set-active-view :filtered-activities-view])
+            (rf/dispatch [:get-content-from-contentful :show-branch (:branch params)])
             (rf/dispatch [:set-active-document-title! (:branch params)]))
 
   (defroute "/activity/#!:activity" {:as params}
-            (rf/dispatch [:get-library-content-from-contentful params])
-            (rf/dispatch [:filter-activities-by-search-term (:activity params)])
-            (rf/dispatch [:set-active-view :activity-view]))
+            (rf/dispatch [:get-content-from-contentful :show-activity (:activity params)]))
 
   (defroute "*" []
             (let [uri (-> js/window .-location .-href)]

--- a/src/cljs/owlet_ui/routes.cljs
+++ b/src/cljs/owlet_ui/routes.cljs
@@ -28,11 +28,8 @@
   (defroute "/unsubscribe" []
             (rf/dispatch [:set-active-view :unsubscribe-view]))
 
-  ;TODO: remove :set-active-document-title!
-
   (defroute "/branches" []
-            (rf/dispatch [:get-content-from-contentful :show-branches])
-            (rf/dispatch [:set-active-document-title! "Branches"]))
+            (rf/dispatch [:get-content-from-contentful :show-branches]))
 
   (defroute "/skill/:skill" {:as params}
             (rf/dispatch [:get-content-from-contentful :show-skill (:skill params)]))
@@ -41,8 +38,7 @@
             (rf/dispatch [:get-content-from-contentful :show-platform (:platform params)]))
 
   (defroute "/branch/:branch" {:as params}
-            (rf/dispatch [:get-content-from-contentful :show-branch (:branch params)])
-            (rf/dispatch [:set-active-document-title! (:branch params)]))
+            (rf/dispatch [:get-content-from-contentful :show-branch (:branch params)]))
 
   (defroute "/activity/#!:activity" {:as params}
             (rf/dispatch [:get-content-from-contentful :show-activity (:activity params)]))

--- a/src/cljs/owlet_ui/views/filtered_activities.cljs
+++ b/src/cljs/owlet_ui/views/filtered_activities.cljs
@@ -5,9 +5,6 @@
             [owlet-ui.helpers :refer [showdown]]
             [owlet-ui.components.email-notification :refer [email-notification]]))
 
-;TODO: update error handling
-
-; (defn filtered-activities-component [filter])
 (defn filtered-activities-view []
   (let [filtered-activities @(rf/subscribe [:activities-by-filter])]
     [:div.branch-activities-wrap
@@ -15,7 +12,7 @@
      (if-not filtered-activities
        [:h2 [:mark.white.box [:b "Loading..."]]]
        (if (= filtered-activities "error")
-         [:h2 [back] [:mark.white.box [:b "Nothing yet, but we're working on it."]]]
+         [:h2 [back] [:mark.white.box [:b "Nothing here. Try a different search above."]]]
          (let [{:keys [display-name activities & description]} filtered-activities]
            [:div
             [:h2 [back]
@@ -42,15 +39,4 @@
                      :let [fields (:fields activity)
                            entry-id (get-in activity [:sys :id])]]
                  ^{:key [entry-id (gensym "key-")]} [activity-thumbnail fields entry-id])
-              [:p.no-activities [:mark (str "No activities for this "  " yet. Check back soon.")]])]])))]))
-
-; (defmulti filtered-activities-view identity)
-;
-; (defmethod filtered-activities-view :skill []
-;   [filtered-activities-component "skill"])
-;
-; (defmethod filtered-activities-view :platform []
-;   [filtered-activities-component "platform"])
-;
-; (defmethod filtered-activities-view :branch []
-;   [filtered-activities-component "branch"])
+              [:p.no-activities [:mark (str "Nothing yet, but we're working on it.")]])]])))]))

--- a/src/cljs/owlet_ui/views/filtered_activities.cljs
+++ b/src/cljs/owlet_ui/views/filtered_activities.cljs
@@ -5,7 +5,10 @@
             [owlet-ui.helpers :refer [showdown]]
             [owlet-ui.components.email-notification :refer [email-notification]]))
 
-(defn filtered-activities-component [filter]
+;TODO: update error handling
+
+; (defn filtered-activities-component [filter])
+(defn filtered-activities-view []
   (let [filtered-activities @(rf/subscribe [:activities-by-filter])]
     [:div.branch-activities-wrap
      [email-notification]
@@ -39,15 +42,15 @@
                      :let [fields (:fields activity)
                            entry-id (get-in activity [:sys :id])]]
                  ^{:key [entry-id (gensym "key-")]} [activity-thumbnail fields entry-id])
-              [:p.no-activities [:mark (str "No activities for this " filter " yet. Check back soon.")]])]])))]))
+              [:p.no-activities [:mark (str "No activities for this "  " yet. Check back soon.")]])]])))]))
 
-(defmulti filtered-activities-view identity)
-
-(defmethod filtered-activities-view :skill []
-  [filtered-activities-component "skill"])
-
-(defmethod filtered-activities-view :platform []
-  [filtered-activities-component "platform"])
-
-(defmethod filtered-activities-view :branch []
-  [filtered-activities-component "branch"])
+; (defmulti filtered-activities-view identity)
+;
+; (defmethod filtered-activities-view :skill []
+;   [filtered-activities-component "skill"])
+;
+; (defmethod filtered-activities-view :platform []
+;   [filtered-activities-component "platform"])
+;
+; (defmethod filtered-activities-view :branch []
+;   [filtered-activities-component "branch"])


### PR DESCRIPTION
v.2

closes https://github.com/codefordenver/owlet/issues/241

TODO:
- [x] get rid of `:process-activity-metadata` dispatch in `:get-library-content-from-contentful`
- [x] stop storing route-params
- [x] resolve timing of `:get-library-content-from-contentful` and `:filter-activities-by-search-term` (see `routes.cljs`)
- [ ] handle `set-path` in `:filter-activities-by-search-term` as an effect? **[deferred]**
- [x] consolidate `:set-activities-by-branch-in-view` with `:filter-activities-by-search-term`
- [x] update error message for search not found
- [ ] revisit `:set-active-document-title!` **[deferred]**