### PR TITLE
fix: disqus bootstrap error onload

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -22,9 +22,8 @@
     </script>
 </head>
 <body>
-<div id="app">
-    <div id="disqus_thread" class="hidden invisible"></div>
-</div>
+<div id="app"></div>
+<div id="disqus_thread" class="hidden invisible"></div>
 <script src="js/vendor/disqus.js"></script>
 <script src="js/compiled/app.js"></script>
 <script>owlet_ui.core.init();</script>


### PR DESCRIPTION
connects to https://waffle.io/codefordenver/owlet/cards/597a879c09fd9800393172c7
closes https://github.com/codefordenver/owlet/issues/246